### PR TITLE
fix(config): remove AddDeprecationNotice call

### DIFF
--- a/templates/internal/appName/config.go.tpl
+++ b/templates/internal/appName/config.go.tpl
@@ -66,9 +66,11 @@ func LoadConfig(ctx context.Context) *Config {
         {{- if has "grpc" (stencil.Arg "serviceActivities") }}
         GRPCPort: 5000,
         {{- end }}
+        /// !!! DEPRECATED: This block is deprecated and will be removed in an upcoming release.
+        /// All configuration should be defined in deployments/{{ .Config.Name }}/{{.Config.Name}}.config.jsonnet.
+        ///
         ///Block(defconfig)
         {{- if file.Block "defconfig" }}
-        {{- file.AddDeprecationNotice (printf "Configuration should be declared in deployments/%s/%s.config.jsonnet" .Config.Name .Config.Name) }}
 {{ file.Block "defconfig" }}
         {{- end }}
         ///EndBlock(defconfig)


### PR DESCRIPTION
<!--
  !!!! README !!!! Please fill this out.

  Please follow the PR naming conventions:
  https://outreach-io.atlassian.net/wiki/spaces/EN/pages/1902444645/Conventional+Commits
-->

<!-- A short description of what your PR does and what it solves. -->

## What this PR does / why we need it

This PR removes a `file.AddDeprecationNotice` call, this functionality was removed in Stencil due to usability issues. Instead a deprecatio notice in the relevant source file has been added.

<!--- Block(jiraPrefix) --->

## Jira ID

[XX-XX]

<!--- EndBlock(jiraPrefix) --->

<!-- Notes that may be helpful for anyone reviewing this PR -->

## Notes for your reviewers

<!--- Block(custom) -->

<!--- EndBlock(custom) -->
