### PR TITLE
fix: remove extra whitespace at the end of the copyright

### DIFF
--- a/templates/api/api.go.tpl
+++ b/templates/api/api.go.tpl
@@ -3,7 +3,7 @@
 {{- end }}
 {{- $_ := file.SetPath (printf "api/%s.go" .Config.Name) }}
 {{- $_ := file.Static }}
-// {{ stencil.ApplyTemplate "copyright" }} 
+// {{ stencil.ApplyTemplate "copyright" }}
 
 // Description: This file defines the gRPC server service interface for
 // {{ .Config.Name }}.

--- a/templates/api/api.proto.tpl
+++ b/templates/api/api.proto.tpl
@@ -3,7 +3,7 @@
 {{- end }}
 {{- $_ := file.SetPath (printf "api/%s.proto" .Config.Name) }}
 {{- $_ := file.Static }}
-// {{ stencil.ApplyTemplate "copyright" }} 
+// {{ stencil.ApplyTemplate "copyright" }}
 // Please modify this to match the interface specified in {{ .Config.Name }}.go
 syntax = "proto3";
 

--- a/templates/api/clients/node/doc.go.tpl
+++ b/templates/api/clients/node/doc.go.tpl
@@ -1,5 +1,5 @@
 {{- $_ := stencil.ApplyTemplate "skipGrpcClient" "node" -}}
-// {{ stencil.ApplyTemplate "copyright" }} 
+// {{ stencil.ApplyTemplate "copyright" }}
 
 // Description: This file just serves as a doc for the client package.
 

--- a/templates/api/clients/node/generate.go.tpl
+++ b/templates/api/clients/node/generate.go.tpl
@@ -1,5 +1,5 @@
 {{- $_ := stencil.ApplyTemplate "skipGrpcClient" "node" -}}
-// {{ stencil.ApplyTemplate "copyright" }} 
+// {{ stencil.ApplyTemplate "copyright" }}
 
 // Description: This file generates the node gRPC client using a gogenerate directive.
 

--- a/templates/api/doc.go.tpl
+++ b/templates/api/doc.go.tpl
@@ -1,7 +1,7 @@
 {{- if not (has "grpc" (stencil.Arg "serviceActivities")) }}
 {{- file.Skip "Not a gRPC service" }}
 {{- end }}
-// {{ stencil.ApplyTemplate "copyright" }} 
+// {{ stencil.ApplyTemplate "copyright" }}
 
 // Description: This file serves as package documentation for the api
 // package.

--- a/templates/api/kubernetes/groupversion_info.go.tpl
+++ b/templates/api/kubernetes/groupversion_info.go.tpl
@@ -1,6 +1,6 @@
 {{ file.Skip "Virtual file to generate kubernetes gvk files" }}
 {{- define "api/kubernetes/groupversion_info" -}}
-// {{ stencil.ApplyTemplate "copyright" }} 
+// {{ stencil.ApplyTemplate "copyright" }}
 
 // Description: This files stores group information
 

--- a/templates/api/kubernetes/type.go.tpl
+++ b/templates/api/kubernetes/type.go.tpl
@@ -1,7 +1,7 @@
 {{ file.Skip "Virtual file to generate kubernetes type files" }}
 
 {{- define "api/kubernetes/type" -}}
-// {{ stencil.ApplyTemplate "copyright" }} 
+// {{ stencil.ApplyTemplate "copyright" }}
 {{- $g := .group }}
 {{- $r := .resource }}
 {{- $isCustomResource := contains "." $g.group }}

--- a/templates/api/kubernetes/version.go.tpl
+++ b/templates/api/kubernetes/version.go.tpl
@@ -1,7 +1,7 @@
 {{ file.Skip "Virtual file to generate kubernetes version files" }}
 
 {{- define "api/kubernetes/version" -}}
-// {{ stencil.ApplyTemplate "copyright" }} 
+// {{ stencil.ApplyTemplate "copyright" }}
 
 // Description: This file triggers generation of the types
 

--- a/templates/api/rpc/doc.go.tpl
+++ b/templates/api/rpc/doc.go.tpl
@@ -2,7 +2,7 @@
 {{- file.Skip "Not a gRPC service" }}
 {{- end }}
 {{- $_ := file.SetPath (printf "api/%s/%s" .Config.Name (base file.Path)) }}
-// {{ stencil.ApplyTemplate "copyright" }} 
+// {{ stencil.ApplyTemplate "copyright" }}
 
 // Description: This file contains the package documentation for the gRPC
 // client service interface package for {{ .Config.Name }}.

--- a/templates/api/rpc_helpers.go.tpl
+++ b/templates/api/rpc_helpers.go.tpl
@@ -1,7 +1,7 @@
 {{- if not (has "grpc" (stencil.Arg "serviceActivities")) }}
 {{- file.Skip "Not a gRPC service" }}
 {{- end }}
-// {{ stencil.ApplyTemplate "copyright" }} 
+// {{ stencil.ApplyTemplate "copyright" }}
 
 // Description: This file contains generic RPC helpers
 

--- a/templates/cmd/main.go.tpl
+++ b/templates/cmd/main.go.tpl
@@ -1,6 +1,6 @@
 {{- file.Skip "Using bootstrap main.go for now" }}
 {{- /* Breaking changes are required for clerk, temporal, and tollmon integration currently */}}
-// {{ stencil.ApplyTemplate "copyright" }} 
+// {{ stencil.ApplyTemplate "copyright" }}
 
 // Description: This file is the entrypoint for {{ .Config.Name }}.
 // Managed: true

--- a/templates/cmd/main_cli.go.tpl
+++ b/templates/cmd/main_cli.go.tpl
@@ -1,7 +1,7 @@
 {{ file.Skip "Virtual file to generate CLIs" }}
 
 {{- define "main-cli" -}}
-// {{ stencil.ApplyTemplate "copyright" }} 
+// {{ stencil.ApplyTemplate "copyright" }}
 
 // Description: This file is the entrypoint for the {{ .cmdName }} CLI
 // command for {{ .Config.Name }}.

--- a/templates/internal/appName/all_test.go.tpl
+++ b/templates/internal/appName/all_test.go.tpl
@@ -1,6 +1,6 @@
 {{- $_ := stencil.ApplyTemplate "skipIfNotService" -}}
 {{- $_ := file.SetPath (printf "internal/%s/%s" .Config.Name (base file.Path)) }}
-// {{ stencil.ApplyTemplate "copyright" }} 
+// {{ stencil.ApplyTemplate "copyright" }}
 
 package {{ stencil.ApplyTemplate "goPackageSafeName" }}_test //nolint:revive // Why: We allow [-_].
 

--- a/templates/internal/appName/config.go.tpl
+++ b/templates/internal/appName/config.go.tpl
@@ -1,6 +1,6 @@
 {{- $_ := stencil.ApplyTemplate "skipIfNotService" -}}
 {{- $_ := file.SetPath (printf "internal/%s/%s" .Config.Name (base file.Path)) }}
-// {{ stencil.ApplyTemplate "copyright" }} 
+// {{ stencil.ApplyTemplate "copyright" }}
 
 // Description: This file is the focal point of configuration that needs passed
 // to various parts of the service.

--- a/templates/internal/appName/doc.go.tpl
+++ b/templates/internal/appName/doc.go.tpl
@@ -1,6 +1,6 @@
 {{- $_ := stencil.ApplyTemplate "skipIfNotService" -}}
 {{- $_ := file.SetPath (printf "internal/%s/%s" .Config.Name (base file.Path)) }}
-// {{ stencil.ApplyTemplate "copyright" }} 
+// {{ stencil.ApplyTemplate "copyright" }}
 
 // Description: This file contains the package documentation for {{ .Config.Name }}.
 

--- a/templates/internal/appName/http/handler.go.tpl
+++ b/templates/internal/appName/http/handler.go.tpl
@@ -3,7 +3,7 @@
 {{ file.Skip "Not a HTTP service" }}
 {{- end }}
 {{- $_ := file.SetPath (printf "internal/%s/%s" .Config.Name (base file.Path)) }}
-// {{ stencil.ApplyTemplate "copyright" }} 
+// {{ stencil.ApplyTemplate "copyright" }}
 
 // Description: This file exposes the public HTTP service for {{ .Config.Name }}.
 

--- a/templates/internal/appName/http/handler_test.go.tpl
+++ b/templates/internal/appName/http/handler_test.go.tpl
@@ -3,7 +3,7 @@
 {{- end }}
 {{- $_ := file.Static }}
 {{- $_ := file.SetPath (printf "internal/%s/%s" .Config.Name (base file.Path)) }}
-// {{ stencil.ApplyTemplate "copyright" }} 
+// {{ stencil.ApplyTemplate "copyright" }}
 
 package {{ stencil.ApplyTemplate "goPackageSafeName" }}_test //nolint:revive // Why: We allow [-_].
 

--- a/templates/internal/appName/http/httpservice.go.tpl
+++ b/templates/internal/appName/http/httpservice.go.tpl
@@ -2,7 +2,7 @@
 {{ file.Skip "Not a service" }}
 {{- end }}
 {{- $_ := file.SetPath (printf "internal/%s/%s" .Config.Name (base file.Path)) }}
-// {{ stencil.ApplyTemplate "copyright" }} 
+// {{ stencil.ApplyTemplate "copyright" }}
 
 // Description: This file exposes the private HTTP service for {{ .Config.Name }}.
 // Managed: true

--- a/templates/internal/appName/k8s/activity.go.tpl
+++ b/templates/internal/appName/k8s/activity.go.tpl
@@ -1,4 +1,4 @@
-// {{ stencil.ApplyTemplate "copyright" }} 
+// {{ stencil.ApplyTemplate "copyright" }}
 {{- $_ := file.SetPath (printf "internal/%s/kubernetes.go" .Config.Name) }}
 {{- $_ := stencil.ApplyTemplate "kubernetes.skipIfNot" }}
 {{- $root := . }}

--- a/templates/internal/appName/k8s/controller.go.tpl
+++ b/templates/internal/appName/k8s/controller.go.tpl
@@ -1,7 +1,7 @@
 {{ file.Skip "Virtual file to create kubernetes controller" }}
 
 {{- define "internal/k8s/controller" -}}
-// {{ stencil.ApplyTemplate "copyright" }} 
+// {{ stencil.ApplyTemplate "copyright" }}
 {{- $g := .group }}
 {{- $r := .resource }}
 {{- $isCustomResource := contains "." $g.group }}

--- a/templates/internal/appName/k8s/doc.go.tpl
+++ b/templates/internal/appName/k8s/doc.go.tpl
@@ -1,4 +1,4 @@
-// {{ stencil.ApplyTemplate "copyright" }} 
+// {{ stencil.ApplyTemplate "copyright" }}
 {{- $_ := file.SetPath (printf "internal/k8s/%s" (base file.Path)) }}
 {{- $_ := stencil.ApplyTemplate "kubernetes.skipIfNot" }}
 

--- a/templates/internal/appName/k8s/resource.go.tpl
+++ b/templates/internal/appName/k8s/resource.go.tpl
@@ -1,4 +1,4 @@
-// {{ stencil.ApplyTemplate "copyright" }} 
+// {{ stencil.ApplyTemplate "copyright" }}
 {{- $_ := file.SetPath (printf "internal/k8s/%s" (base file.Path)) }}
 {{- $_ := stencil.ApplyTemplate "kubernetes.skipIfNot" }}
 

--- a/templates/internal/appName/k8s/type_doc.go.tpl
+++ b/templates/internal/appName/k8s/type_doc.go.tpl
@@ -1,7 +1,7 @@
 {{ file.Skip "Virtual file to create kubernetes webhook/controller doc.go" }}
 
 {{- define "internal/k8s/doc" -}}
-// {{ stencil.ApplyTemplate "copyright" }} 
+// {{ stencil.ApplyTemplate "copyright" }}
 
 // Description: This file is docs for {{ .group }}/{{ .version }}.
 // Managed: true

--- a/templates/internal/appName/k8s/webhook.go.tpl
+++ b/templates/internal/appName/k8s/webhook.go.tpl
@@ -1,7 +1,7 @@
 {{ file.Skip "Virtual file to create kubernetes webhook" }}
 
 {{- define "internal/k8s/webhook" -}}
-// {{ stencil.ApplyTemplate "copyright" }} 
+// {{ stencil.ApplyTemplate "copyright" }}
 {{- $g := .group }}
 {{- $r := .resource }}
 {{- $webhookStruct := printf "%sWebhook" $r.kind }}

--- a/templates/internal/appName/kafka/consumer.go.tpl
+++ b/templates/internal/appName/kafka/consumer.go.tpl
@@ -2,7 +2,7 @@
 {{ file.Skip "Not a Kafka service" }}
 {{- end }}
 {{- $_ := file.SetPath (printf "internal/%s/%s" .Config.Name (base file.Path)) }}
-// {{ stencil.ApplyTemplate "copyright" }} 
+// {{ stencil.ApplyTemplate "copyright" }}
 
 // Description: This file is responsible for creating consumers of kafka streams.
 // Managed: true

--- a/templates/internal/appName/rpc/server.go.tpl
+++ b/templates/internal/appName/rpc/server.go.tpl
@@ -3,7 +3,7 @@
 {{- end }}
 {{- $_ := file.SetPath (printf "internal/%s/%s" .Config.Name (base file.Path)) }}
 {{- $_ := file.Static }}
-// {{ stencil.ApplyTemplate "copyright" }} 
+// {{ stencil.ApplyTemplate "copyright" }}
 
 // Description: This file contains the gRPC server implementation for the {{ .Config.Name }}
 // API defined in api/{{ .Config.Name }}.proto. This implementation is used in the

--- a/templates/internal/appName/shutdown.go.tpl
+++ b/templates/internal/appName/shutdown.go.tpl
@@ -1,6 +1,6 @@
 {{- $_ := stencil.ApplyTemplate "skipIfNotService" -}}
 {{- $_ := file.SetPath (printf "internal/%s/%s" .Config.Name (base file.Path)) }}
-// {{ stencil.ApplyTemplate "copyright" }} 
+// {{ stencil.ApplyTemplate "copyright" }}
 
 // Description: This file implements a service that handles graceful shutdowns.
 // Managed: true


### PR DESCRIPTION
remove extra whitespace at the end of the copyright