### PR TITLE
feat: allow toggling metrics collector

### DIFF
--- a/manifest.yaml
+++ b/manifest.yaml
@@ -26,6 +26,10 @@ arguments:
     type: string
     description: lintroller level to apply to this repository
     default: platinum
+  metrics:
+    type: string
+    descriptions: Metrics collector to use (supports opentelemetry and datadog)
+    default: datadog
   vaultSecrets:
     type: list
     description: List of secrets to consume from Vault, if Vault is enabled in the box config

--- a/manifest.yaml
+++ b/manifest.yaml
@@ -27,7 +27,8 @@ arguments:
     description: lintroller level to apply to this repository
     default: platinum
   metrics:
-    type: string
+    schema: 
+      type: string
     descriptions: Metrics collector to use (supports opentelemetry and datadog)
     default: datadog
   vaultSecrets:

--- a/templates/deployments/appname/app.jsonnet.tpl
+++ b/templates/deployments/appname/app.jsonnet.tpl
@@ -149,10 +149,17 @@ local all = {
         metadata+: {
           {{- if (has "grpc" (stencil.Arg "serviceActivities")) }}
           labels+: sharedLabels {
-            'tollgate.outreach.io/scrape': 'true'
+            'tollgate.outreach.io/scrape': 'true',
+            {{- if (eq "opentelemetry" (stencil.Arg "metrics")) }}
+            'opentelemetry.io/scrape': 'true',
+            {{- end }}
           },
           {{- else }}
-          labels+: sharedLabels,
+          labels+: sharedLabels {
+            {{- if (eq "opentelemetry" (stencil.Arg "metrics")) }}
+            'opentelemetry.io/scrape': 'true',
+            {{- end }}
+          },
           {{- end }}
           annotations+: {
             {{- if (has "grpc" (stencil.Arg "serviceActivities")) }}
@@ -160,6 +167,7 @@ local all = {
             'tollgate.outreach.io/port': '5000',
             {{- end }}
             'iam.amazonaws.com/role': '%s_service_role' % app.name,
+            {{- if (eq "datadog" (stencil.Arg "metrics")) }}
             // https://docs.datadoghq.com/integrations/openmetrics/
             ['ad.datadoghq.com/' + app.name + '.check_names']: '["openmetrics"]',
             ['ad.datadoghq.com/' + app.name + '.init_configs']: '[{}]',
@@ -186,6 +194,7 @@ local all = {
                 send_distribution_buckets: true,
               },
             ],
+            {{- end }}
             {{- end }}
           },
         },


### PR DESCRIPTION
<!--
  !!!! README !!!! Please fill this out.

  Please follow the PR naming conventions:
  https://outreach-io.atlassian.net/wiki/spaces/EN/pages/1902444645/Conventional+Commits
-->

<!-- A short description of what your PR does and what it solves. -->

## What this PR does / why we need it

Adds support for toggling between `datadog` and `opentelemetry` as the metrics collector.

<!--- Block(jiraPrefix) --->

## Jira ID

[DTSS-1818]

<!--- EndBlock(jiraPrefix) --->

<!-- Notes that may be helpful for anyone reviewing this PR -->

## Notes for your reviewers

<!--- Block(custom) -->

<!--- EndBlock(custom) -->


[DTSS-1818]: https://outreach-io.atlassian.net/browse/DTSS-1818?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ