### PR TITLE
fix: adds doculint nolint for doc.go

### DIFF
--- a/templates/internal/appName/doc.go.tpl
+++ b/templates/internal/appName/doc.go.tpl
@@ -6,4 +6,4 @@
 
 // Package {{ stencil.ApplyTemplate "goPackageSafeName" }} contains the base activities
 // that make up the service.
-package {{ stencil.ApplyTemplate "goPackageSafeName" }} //nolint:revive // Why: We allow [-_].
+package {{ stencil.ApplyTemplate "goPackageSafeName" }} //nolint:revive,doculint // Why: We allow [-_].


### PR DESCRIPTION
fixes linter error from doculint on hyphens
