### PR TITLE
feat: add monitoring terraform templates

### DIFF
--- a/manifest.yaml
+++ b/manifest.yaml
@@ -1,5 +1,7 @@
 name: github.com/getoutreach/stencil-golang
 ###Block(keys)
+modules:
+  - name: github.com/getoutreach/stencil-discovery
 arguments:
   service:
     type: bool
@@ -29,6 +31,9 @@ arguments:
   metrics:
     schema:
       type: string
+      enum:
+        - datadog
+        - opentelemetry
     description: Metrics collector to use (supports opentelemetry and datadog)
     default: datadog
   tracing:
@@ -36,10 +41,6 @@ arguments:
       type: string
     descriptions: Tracing backend to send traces to (support opentelemetry and honeycomb)
     default: honeycomb
-  bentos:
-    schema:
-      type: array
-    description: List of bentos the service will be deployed to
   slack:
     schema:
       type: string
@@ -128,4 +129,21 @@ arguments:
     schema:
       type: integer
     description: Overrides the min available replica count in the "available_pods_low" alert in terraform module in monitoring/datadog.tf.
+  deployTo.serviceDomain:
+    description: The service domain that the service is needs deployed to.
+    schema:
+      type: string
+      enum:
+        - bento
+        - shared-service
+  deployTo.environments:
+    description: A list of environments that the service is deployed to.
+    schema:
+      type: array
+      items:
+        type: string
+        enum:
+          - ops
+          - staging
+          - production
 ###EndBlock(keys)

--- a/manifest.yaml
+++ b/manifest.yaml
@@ -27,15 +27,23 @@ arguments:
     description: lintroller level to apply to this repository
     default: platinum
   metrics:
-    schema: 
+    schema:
       type: string
-    descriptions: Metrics collector to use (supports opentelemetry and datadog)
+    description: Metrics collector to use (supports opentelemetry and datadog)
     default: datadog
   tracing:
     schema:
       type: string
     descriptions: Tracing backend to send traces to (support opentelemetry and honeycomb)
     default: honeycomb
+  bentos:
+    schema:
+      type: array
+    description: List of bentos the service will be deployed to
+  slack:
+    schema:
+      type: string
+    description: Slack channel to send deployment messages into.
   vaultSecrets:
     type: list
     description: List of secrets to consume from Vault, if Vault is enabled in the box config
@@ -56,4 +64,68 @@ arguments:
   dependencies.required:
     type: list
     description: Dependencies your repository requires to run successfully no matter what.
+  terraform.datadog.grpc.tags:
+    schema:
+      type: array
+    description: Filter metrics used to create monitors and alerts in Datadog for gRPC related events.
+  terraform.datadog.grpc.evaluationWindow:
+    schema:
+      type: string
+    description: The window of time to evaluate metrics related to gRPC events for each monitor and alert.
+  terraform.datadog.grpc.lowTrafficCountThreshold:
+    schema:
+      type: integer
+    description: Overrides the low count threshold in the "grpc_latency_high" & "grpc_success_rate_low" terraform modules in monitoring/datadog.tf.
+  terraform.datadog.grpc.latency.percentiles.lowTraffic:
+    schema:
+      type: integer
+    description: Overrides the low traffic percentile in the "grpc_latency_high" terraform module in monitoring/datadog.tf.
+  terraform.datadog.grpc.latency.percentiles.highTraffic:
+    schema:
+      type: integer
+    description: Overrides the high traffic percentile in the "grpc_latency_high" terraform module in monitoring/datadog.tf.
+  terraform.datadog.grpc.latency.thresholds.lowTraffic:
+    schema:
+      type: integer
+    description: Overrides the low traffic threshold in the "grpc_latency_high" terraform module in monitoring/datadog.tf.
+  terraform.datadog.grpc.latency.thresholds.highTraffic:
+    schema:
+      type: integer
+    description: Overrides the high traffic threshold in the "grpc_latency_high" terraform module in monitoring/datadog.tf.
+  terraform.datadog.grpc.qos.thresholds.lowTraffic:
+    schema:
+      type: integer
+    description: Overrides the low traffic threshold in the "grpc_latency_high" terraform module in monitoring/datadog.tf.
+  terraform.datadog.grpc.qos.thresholds.highTraffic:
+    schema:
+      type: integer
+    description: Overrides the high traffic threshold in the "grpc_latency_high" terraform module in monitoring/datadog.tf.
+  terraform.datadog.http.evaluationWindow:
+    schema:
+      type: string
+    description: The window of time to evaluate metrics related to HTTP events for each monitor and alert.
+  terraform.datadog.http.percentiles.lowTraffic:
+    schema:
+      type: integer
+    description: Overrides the low traffic percentile in the "http_success_rate_low" terraform module in monitoring/datadog.tf.
+  terraform.datadog.http.percentiles.highTraffic:
+    schema:
+      type: integer
+    description: Overrides the high traffic percentile in the "http_success_rate_low" terraform module in monitoring/datadog.tf.
+  terraform.datadog.http.thresholds.lowCount:
+    schema:
+      type: integer
+    description: Overrides the low count threshold in the "http_success_rate_low" terraform module in monitoring/datadog.tf.
+  terraform.datadog.http.thresholds.lowTraffic:
+    schema:
+      type: integer
+    description: Overrides the low traffic threshold in the "http_success_rate_low" terraform module in monitoring/datadog.tf.
+  terraform.datadog.http.thresholds.highTraffic:
+    schema:
+      type:  integer
+    description: Overrides the high traffic threshold in the "http_success_rate_low" terraform module in monitoring/datadog.tf.
+  terraform.datadog.pods.thresholds.availableLowCount:
+    schema:
+      type: integer
+    description: Overrides the min available replica count in the "available_pods_low" alert in terraform module in monitoring/datadog.tf.
 ###EndBlock(keys)

--- a/templates/monitoring/dashboard.tf.tpl
+++ b/templates/monitoring/dashboard.tf.tpl
@@ -1,0 +1,281 @@
+# This file is managed by {{  .Runtime.Generator }}.  Changes outside of `Block`s will be
+# clobbered next time it is run.
+
+# This file defines a very generic infrastructure-level dashboard.  It provides
+# visibility into service attributes that are generic across services, like k8s
+# metrics or counts of gRPC calls.
+#
+# Most services will need more dashboards that include more service-specific
+# information.  You can define them in the Datadog UI or a separate `.tf` file
+# in this directory according to your preference.
+
+# Pro tip: For best results, visit
+# https://app.datadoghq.com/metric/summary?metric={{ .Config.Name }}.grpc_request_handled
+# and set the unit metadata to "seconds".  This will make the y axes on some of
+# these charts much more readable.
+{{- $deployment  := stencil.ApplyTemplate "goPackageSafeName" }}
+
+locals {
+  dashboard_parameters = [
+    {
+      name    = "bento"
+      prefix  = "bento"
+      default = "*"
+    },
+    {
+      name    = "env"
+      prefix  = "env"
+      default = "*"
+    },
+    ///Block(customDashboardParams)
+{{ file.Block "customDashboardParams" }}
+    ///EndBlock(customDashboardParams)
+  ]
+}
+
+# Header section: Here we include descriptions, links and other info.
+
+locals {
+  standard_links = [
+    "[GitHub](https://github.com/getoutreach/{{ .Config.Name }})",
+    "[Engdocs](https://engdocs.outreach.cloud/github.com/getoutreach/{{ .Config.Name }})",
+    "[Logs](https://app.datadoghq.com/logs?cols=service%2C%40bento%2Csource&from_ts=1601507372082&index=main&live=true&messageDisplay=expanded-md&stream_sort=desc&to_ts=1601508272082&query=service%3A{{ .Config.Name }})",
+    "[Honeycomb](https://ui.honeycomb.io/outreach-a0/datasets/outreach?query=%7B%22breakdowns%22%3A%5B%22service_name%22%2C%22name%22%2C%22deployment.bento%22%5D%2C%22calculations%22%3A%5B%7B%22op%22%3A%22COUNT%22%7D%2C%7B%22column%22%3A%22duration_ms%22%2C%22op%22%3A%22P90%22%7D%2C%7B%22column%22%3A%22duration_ms%22%2C%22op%22%3A%22HEATMAP%22%7D%5D%2C%22filters%22%3A%5B%7B%22column%22%3A%22service_name%22%2C%22op%22%3A%22exists%22%2C%22join_column%22%3A%22%22%7D%2C%7B%22column%22%3A%22service_name%22%2C%22op%22%3A%22%3D%22%2C%22value%22%3A%22{{ .Config.Name }}%22%2C%22join_column%22%3A%22%22%7D%5D%2C%22orders%22%3A%5B%7B%22op%22%3A%22COUNT%22%2C%22order%22%3A%22descending%22%7D%5D%2C%22limit%22%3A1000%2C%22time_range%22%3A604800%7D)",
+    "[Owning GitHub team](https://github.com/orgs/getoutreach/teams/{{  stencil.Arg "reportingTeam" }})",
+    "[Deployment Slack](https://slack.com/app_redirect?channel={{ stencil.Arg "slack" }})",
+    "[Concourse CI/CD](https://concourse.outreach.cloud/teams/devs/pipelines/{{ .Config.Name }})",
+  ]
+  custom_links = [
+///Block(customLinks)
+{{ file.Block "customLinks" }}
+///EndBlock(customLinks)
+  ]
+
+  formatted_links = join("\n", formatlist("- %s", concat(local.standard_links, local.custom_links)))
+  links_note_content = join("", ["See also:\n\n", local.formatted_links])
+}
+
+module "links_note" {
+  source = "git@github.com:getoutreach/monitoring-terraform.git//modules/dd-chart/generic/note"
+  content = local.links_note_content
+}
+
+module "description_note" {
+  source = "git@github.com:getoutreach/monitoring-terraform.git//modules/dd-chart/generic/note"
+  content = <<-EOF
+    # {{ .Config.Name | title }}
+
+    This is the terraform-managed dashboard for the {{ .Config.Name }} service.
+  EOF
+}
+
+locals {
+  header_section = {
+    name = "{{ .Config.Name | title }} Service Info"
+    charts = [
+      module.description_note.rendered,
+      module.links_note.rendered,
+    ]
+  }
+}
+
+# Deployment section: k8s-level service information.
+
+module "deployment" {
+  source     = "git@github.com:getoutreach/monitoring-terraform.git//modules/dd-sections/generic_deployment"
+  deployment = "{{ $deployment }}"
+}
+
+{{- if has "grpc" (stencil.Arg "serviceActivities") }}
+
+# NOTE: applies for most of the gRPC sections below.
+#
+# The term "calls" is a bit misleading here.  The metrics series do not clearly
+# differentiate between calls made by the service and calls into this service.
+# We need to fix that at the metrics level then update these charts accordingly.
+#  See https://outreach-io.atlassian.net/browse/DT-294.
+#
+# Until that's fixed, you could try adding sections for particular kinds of
+# calls.  When this template is instantiated with `call` arguments that match
+# the name of a particular gRPC method then you'll see only the top-level
+# requests for that method and you won't need to worry about the hetorgenous
+# mix of calls in the unfiltered metric.
+
+# This section shows call/request counts in details
+#
+# Charts on display in this section are:
+# - total number of calls/requests within selected time period
+# - timeseries of calls per status (ok/error)
+# - timeseries of calls per bento
+# - top list of "busy" bentos
+# - top list of "popular" calls
+# - RPS, average for the selected time period
+# - RPS, timeseries
+# - RPM, average for the selected time period
+# - RPM, timeseries
+
+module "grpc_load" {
+  source     = "git@github.com:getoutreach/bootstrap-terraform.git//monitoring/datadog/section/grpc/load?ref=v1.1.0"
+  deployment = "{{ $deployment }}"
+}
+
+# This section shows performance/latency of calls.
+#
+# Charts on display in this section are:
+# - P99 latency, average for the selected time period
+# - P99 latency, timeseries
+# - P99 latency, top "slow" bentos
+# - P95 latency, average for the selected time period
+# - P95 latency, timeseries
+# - P95 latency, top "slow" bentos
+# - table of latencies per percentile
+# - table of latencies per percentile and bento
+# - table of latencies per percentile and call type
+# - P99/95/90/75/50 latency, timeseries
+#
+# This section uses a pair of threshold variables
+# that can be overriden in `terraform.tfvars`.
+
+variable Latency_red_line_ms {
+  type    = number
+  default = 500
+}
+variable Latency_yellow_line_ms {
+  type    = number
+  default = 200
+}
+
+module "grpc_performance" {
+  source     = "git@github.com:getoutreach/bootstrap-terraform.git//monitoring/datadog/section/grpc/perf?ref=v1.1.0"
+  deployment = "{{ $deployment }}"
+}
+
+# This section shows QoS and rate of successfully finished calls.
+#
+# Charts on display in this section are:
+# - Success rate, average for the selected time period
+# - Success rate, timeseries
+# - Success rate by bento
+# - Success rate, top "error producing" bentos
+# - Success rate, top "error producing" calls
+# - Top list of error status codes
+# - Error counts, timeseries
+#
+# This section uses a pair of threshold variables
+# that can be overriden in `terraform.tfvars`.
+
+variable Qos_red_line {
+  type    = number
+  default = 98
+}
+variable Qos_yellow_line {
+  type    = number
+  default = 99
+}
+
+module "grpc_qos" {
+  source     = "git@github.com:getoutreach/bootstrap-terraform.git//monitoring/datadog/section/grpc/qos?ref=v1.1.0"
+  deployment = "{{ $deployment }}"
+}
+
+# This section shows calls activity per bento.
+# It also highlights anomalies in call patterns compared to the metrics
+# reported in the past.
+
+module "grpc_bento_activity" {
+  source     = "git@github.com:getoutreach/bootstrap-terraform.git//monitoring/datadog/section/grpc/activity?ref=v1.1.0"
+  deployment = "{{ $deployment }}"
+}
+{{- end }}
+
+{{- if has "temporal" (stencil.Arg "serviceActivities") }}
+module "temporal_qos" {
+  source     = "git@github.com:getoutreach/bootstrap-terraform.git//monitoring/datadog/section/temporal/qos?ref=v1.1.0"
+  deployment = "{{ $deployment }}"
+}
+
+module "temporal_activity" {
+  source     = "git@github.com:getoutreach/bootstrap-terraform.git//monitoring/datadog/section/temporal/activity?ref=v1.1.0"
+  deployment = "{{ $deployment }}"
+}
+
+module "temporal_latency" {
+  source     = "git@github.com:getoutreach/bootstrap-terraform.git//monitoring/datadog/section/temporal/latency?ref=v1.1.0"
+  deployment = "{{ $deployment }}"
+}
+
+module "temporal_workflow" {
+  source     = "git@github.com:getoutreach/bootstrap-terraform.git//monitoring/datadog/section/temporal/workflow?ref=v1.1.0"
+  deployment = "{{ $deployment }}"
+}
+
+module "temporal_resources" {
+  source     = "git@github.com:getoutreach/bootstrap-terraform.git//monitoring/datadog/section/temporal/resources?ref=v1.1.0"
+  deployment = "{{ $deployment }}"
+}
+{{- end }}
+
+# You can define additional sections here if needed.
+
+///Block(sectionDefinitions)
+{{- if file.Block "sectionDefinitions" }}
+{{ file.Block "sectionDefinitions" }}
+{{- else }}
+# If you would like to instantiate additional dashboard section templates, you
+# can do so here.  For example, if you wanted to include standard charts for
+# some hypothetical "pongrequest" gRPC call, you could do:
+#
+# module "grpc_pongrequest" {
+#   source     = "git@github.com:getoutreach/monitoring-terraform.git//modules/dd-sections/bootstrap_grpc"
+#   deployment = "{{ $deployment }}"
+#   call       = "api.{{ .Config.Name }}.pongrequest"
+# }
+#
+# Don't forget to instantiate the new section by referencing it in the
+# dashboard definition below.
+{{- end }}
+///EndBlock(sectionDefinitions)
+
+# Here we render the dashboard.
+
+module "dashboard" {
+  source = "git@github.com:getoutreach/monitoring-terraform.git//modules/dd-dashboards"
+  name = "Terraform: {{ .Config.Name | title }}"
+  description = "Managed by terraform in github.com/getoutreach/{{ .Config.Name }}"
+
+  parameters = local.dashboard_parameters
+  sections = [
+    local.header_section,
+{{- if has "grpc" (stencil.Arg "serviceActivities") }}
+    module.grpc_load.rendered,
+    module.grpc_performance.rendered,
+    module.grpc_qos.rendered,
+    module.grpc_bento_activity.rendered,
+{{- end }}
+    module.deployment.rendered,
+///Block(sectionReferences)
+{{ file.Block "sectionReferences" }}
+///EndBlock(sectionReferences)
+  ]
+}
+
+{{- if has "temporal" (stencil.Arg "serviceActivities") }}
+module "temporaldashboard" {
+  source      = "git@github.com:getoutreach/monitoring-terraform.git//modules/dd-dashboards"
+  name        = "Terraform: {{ .Config.Name | title }} Temporal"
+  description = "Managed by terraform in github.com/getoutreach/{{ .Config.Name }}"
+
+  parameters = local.dashboard_parameters
+  sections = [
+    module.temporal_qos.rendered,
+    module.temporal_activity.rendered,
+    module.temporal_latency.rendered,
+    module.temporal_workflow.rendered,
+    module.temporal_resources.rendered,
+///Block(sectionTemporalReferences)
+{{ file.Block "sectionTemporalReferences" }}
+///EndBlock(sectionTemporalReferences)
+  ]
+}
+{{- end }}
+

--- a/templates/monitoring/datadog.tf.tpl
+++ b/templates/monitoring/datadog.tf.tpl
@@ -328,8 +328,9 @@ resource "datadog_service_level_objective" "grpc_p99_latency" {
   tags = local.ddTags
   monitor_ids = [module.grpc_latency_high.high_traffic_id]
   groups = [
-    {{- range $b := stencil.Arg "bentos" }}
-    "kube_namespace:{{ stencil.ApplyTemplate "goPackageSafeName" }}--{{ $b }}",
+    {{- $bentos := extensions.Call "github.com/getoutreach/stencil-discovery.Bentos" (stencil.Arg "deployTo.environments") (stencil.Arg "deployTo.serviceDomain")}}
+    {{- range $b := $bentos }}
+    "kube_namespace:{{ stencil.ApplyTemplate "goPackageSafeName" }}--{{ $b.name }}",
     {{- end }}
   ]
   thresholds {

--- a/templates/monitoring/datadog.tf.tpl
+++ b/templates/monitoring/datadog.tf.tpl
@@ -1,0 +1,471 @@
+variable P1_notify {
+  type = list(string)
+  default = []
+}
+variable P2_notify {
+  type = list(string)
+  default = []
+}
+variable additional_dd_tags {
+  type = list(string)
+  default = []
+}
+
+variable cpu_high_threshold {
+  type = number
+  default = 80
+}
+
+# window in minutes
+variable cpu_high_window { 
+  type = number
+  default = 30
+}
+
+# Number of restarts per 30m to be considered a P1 incident.
+variable pod_restart_threshold {
+  type = number
+  default = 3
+}
+
+variable "alert_on_panics" {
+  type        = bool
+  default     = true
+  description = "Enables/Disables the panics monitor defined based on the logs"
+}
+
+locals {
+  ddTags = concat(["{{ .Config.Name }}", "team:{{  stencil.Arg "reportingTeam" }}"], var.additional_dd_tags)
+}
+
+# splitting the interval 15 mins to 3 windows (moving rollup by 5mins) and if each of them contains restart -> alert
+resource "datadog_monitor" "pod_restarts" {
+  type = "query alert"
+  name = "{{ .Config.Name | title }} Pod Restarts > 0 last 15m"
+  query = "min(last_15m):moving_rollup(diff(sum:kubernetes_state.container.restarts{kube_container_name:{{ .Config.Name }},!env:development} by {kube_namespace}), 300, 'sum') > 0"
+  tags = local.ddTags
+  message = <<EOF
+  If we ever have a pod restart, we want to know.
+  Note: This monitor will auto-resolve after 15 minutes of no restarts.
+  Runbook: "https://github.com/getoutreach/{{ .Config.Name }}/blob/main/documentation/runbooks/pod-restarts.md"
+  Notify: ${join(" ", var.P2_notify)}
+  EOF
+  require_full_window = false
+}
+
+resource "datadog_monitor" "pod_restarts_high" {
+  type = "query alert"
+  name = "{{ .Config.Name | title }} Pod Restarts > ${var.pod_restart_threshold} last 30m"
+  query = "max(last_30m):diff(sum:kubernetes_state.container.restarts{kube_container_name:{{ .Config.Name }},!env:development} by {kube_namespace}) > ${var.pod_restart_threshold}"
+  tags = local.ddTags
+  message = <<EOF
+  Several pods are being restarted.
+  Note: This monitor will auto-resolve after 30 minutes of no restarts.
+  Runbook: "https://github.com/getoutreach/{{ .Config.Name }}/blob/main/documentation/runbooks/pod-restarts.md"
+  Notify: ${join(" ", var.P1_notify)}
+  EOF
+  require_full_window = false
+}
+
+# default to 0 if the pod was running on high CPU and then stopped/killed
+resource "datadog_monitor" "pod_cpu_high" {
+  type = "query alert"
+  name = "{{ .Config.Name | title }} Pod CPU > ${var.cpu_high_threshold}% of request last ${var.cpu_high_window}m"
+  query = "avg(last_${var.cpu_high_window}m):100 * (default_zero(avg:kubernetes.cpu.usage.total{app:{{ .Config.Name }},!env:development} by {kube_namespace,pod_name}) / 1000000000) / avg:kubernetes.cpu.requests{app:{{ .Config.Name }},!env:development} by {kube_namespace} >= ${var.cpu_high_threshold}"
+  tags = local.ddTags
+  message = <<EOF
+  One of the service's pods has been using over ${var.cpu_high_threshold}% of its requested CPU on average for the last ${var.cpu_high_window} minutes.  This almost certainly means that the service needs more CPU to function properly and is being throttled in its current form.
+  Runbook: "https://github.com/getoutreach/{{ .Config.Name }}/blob/main/documentation/runbooks/pod-cpu.md"
+  Notify: ${join(" ", var.P2_notify)}
+  EOF
+  require_full_window = false
+}
+
+resource "datadog_monitor" "pod_memory_rss_high" {
+  type = "query alert"
+  name = "{{ .Config.Name | title }} Pod Memory.rss > 80% of limit last 30m"
+  query = "avg(last_30m):moving_rollup(default_zero(100 * avg:kubernetes.memory.rss{app:{{ .Config.Name }},!env:development} by {kube_namespace,pod_name} / avg:kubernetes.memory.limits{app:{{ .Config.Name }},!env:development} by {kube_namespace}), 60, 'max') >= 80"
+  tags = local.ddTags
+  message = <<EOF
+  One of the service's pods has been using over 80% of its limit memory on average for the last 30 minutes.  This almost certainly means that the service needs more memory to function properly and is being throttled in its current form due to GC patterns and/or will be OOMKilled if consumption increases.
+  Runbook: "https://github.com/getoutreach/{{ .Config.Name }}/blob/main/documentation/runbooks/pod-memory.md"
+  Notify: ${join(" ", var.P2_notify)}
+  EOF
+  require_full_window = false
+}
+
+resource "datadog_monitor" "pod_memory_working_set_high" {
+  type = "query alert"
+  name = "{{ .Config.Name | title }} Pod Memory.working_set > 80% of limit last 30m"
+  query = "avg(last_30m):moving_rollup(default_zero(100 * avg:kubernetes.memory.working_set{app:{{ .Config.Name }},!env:development} by {kube_namespace,pod_name} / avg:kubernetes.memory.limits{app:{{ .Config.Name }},!env:development} by {kube_namespace}), 60, 'max') >= 80"
+  tags = local.ddTags
+  message = <<EOF
+  One of the service's pods has been using over 80% of its limit memory on average for the last 30 minutes.  This almost certainly means that the service needs more memory to function properly and is being throttled in its current form due to GC patterns and/or will be OOMKilled if consumption increases.
+  Runbook: "https://github.com/getoutreach/{{ .Config.Name }}/blob/main/documentation/runbooks/pod-memory.md"
+  Notify: ${join(" ", var.P2_notify)}
+  EOF
+  require_full_window = false
+}
+
+variable available_pods_low_count {
+  type    = number
+  default = {{ stencil.Arg "terraform.datadog.pods.thresholds.availableLowCount" | default 2 }}
+}
+
+resource "datadog_monitor" "available_pods_low" {
+  type = "query alert"
+  name = "{{ .Config.Name | title }} Available Pods Low"
+  query = "max(last_10m):avg:kubernetes_state.deployment.replicas_available{deployment:{{ .Config.Name }},env:production} by {kube_namespace} < ${var.available_pods_low_count}"
+  tags = local.ddTags
+  message = <<EOF
+  The {{ .Config.Name | title }} replica count should be at least ${var.available_pods_low_count}, which is also the PDB.  If it's lower, that's below the PodDisruptionBudget and we're likely headed toward a total outage of {{ .Config.Name | title }}.
+  Note: This P1 alert only includes production
+  Runbook: "https://github.com/getoutreach/{{ .Config.Name }}/blob/main/documentation/runbooks/available-pods-low.md"
+  Notify: ${join(" ", var.P1_notify)}
+  EOF
+}
+
+resource "datadog_monitor" "panics" {
+  type    = "log alert"
+  name    = "{{ .Config.Name | title }} Service panics"
+  query   = "logs(\"panic status:error service:{{ .Config.Name }} -env:development\").index(\"*\").rollup(\"count\").by(\"kube_namespace\").last(\"5m\") > 0"
+  tags    = local.ddTags
+  message = <<EOF
+  Log based monitor of runtime error panics.
+  Note: This P1 alert only includes production
+  Runbook: "https://github.com/getoutreach/{{ .Config.Name }}/blob/main/documentation/runbooks/service-panics.md"
+  Notify: ${join(" ", var.P1_notify)}
+  EOF
+}
+
+resource "datadog_downtime" "panics_silence" {
+  scope      = ["*"]
+  monitor_id = datadog_monitor.panics.id
+  count      = var.alert_on_panics ? 0 : 1
+}
+
+{{- if has "http" (stencil.Arg "serviceActivities") }}
+variable http_success_rate_low_traffic_percentile {
+  type    = number
+  default = {{ stencil.Arg "terraform.datadog.http.percentiles.lowTraffic" | default 90 }}
+}
+
+variable http_success_rate_high_traffic_percentile {
+  type    = number
+  default = {{ stencil.Arg "terraform.datadog.http.percentiles.highTraffic" | default 99 }}
+}
+
+variable http_success_rate_low_count_threshold {
+  type    = number
+  default = {{ stencil.Arg "terraform.datadog.http.thresholds.lowCount" | default 1000 }}
+}
+
+variable http_success_rate_evaluation_window {
+  type    = string
+  default = {{ stencil.Arg "terraform.datadog.http.evaluationWindow" | default "last_15m" | quote }}
+}
+
+module "http_success_rate_low" {
+  source = "git@github.com:getoutreach/monitoring-terraform.git//modules/alerts/datadog/low-traffic-composite-monitor"
+  name = "{{ .Config.Name | title }} HTTP Success Rate Low (P${var.http_success_rate_high_traffic_percentile}H/P${var.http_success_rate_low_traffic_percentile}L)"
+  tags = local.ddTags
+  message = <<EOF
+  Composite monitor calculating the success rate of non-5xx requests as a 0-100% monitor.
+  High traffic -> P${var.http_success_rate_high_traffic_percentile}
+  Low traffic -> P${var.http_success_rate_low_traffic_percentile}
+  Low traffic count < ${var.http_success_rate_low_count_threshold}
+  Runbook: "https://github.com/getoutreach/{{ .Config.Name }}/blob/main/documentation/runbooks/http-success-rate-low.md"
+  Notify: ${join(" ", var.P2_notify)}
+  EOF
+  require_full_window = false
+  low_count_query = "sum(${var.http_success_rate_evaluation_window}):count:{{ stencil.ApplyTemplate "goPackageSafeName" }}.http_request_seconds{!status:5xx,!env:development} by {kube_namespace}.as_count() < ${var.http_success_rate_low_count_threshold}"
+  low_traffic_query = "sum(${var.http_success_rate_evaluation_window}):100 * ( count:{{ stencil.ApplyTemplate "goPackageSafeName" }}.http_request_seconds{!status:5xx,!env:development} by {kube_namespace}.as_count() / count:{{ stencil.ApplyTemplate "goPackageSafeName" }}.http_request_seconds{*, !env:development} by {kube_namespace}.as_count() ) < ${var.http_success_rate_low_traffic_percentile}"
+  high_traffic_query = "sum(${var.http_success_rate_evaluation_window}):100 * ( count:{{ stencil.ApplyTemplate "goPackageSafeName" }}.http_request_seconds{!status:5xx,!env:development} by {kube_namespace}.as_count() / count:{{ stencil.ApplyTemplate "goPackageSafeName" }}.http_request_seconds{*, !env:development} by {kube_namespace}.as_count() ) < ${var.http_success_rate_high_traffic_percentile}"
+}
+
+module "http_latency_high" {
+  source = "git@github.com:getoutreach/monitoring-terraform.git//modules/alerts/datadog/low-traffic-composite-monitor"
+  name = "{{ .Config.Name | title }} HTTP Latency High (P99H/P90L)"
+  tags = local.ddTags
+  message = <<EOF
+  Composite monitor based on traffic
+  High traffic -> P99
+  Low traffic -> P90
+  Runbook: "https://github.com/getoutreach/{{ .Config.Name }}/blob/main/documentation/runbooks/http-latency-high.md"
+  Notify: ${join(" ", var.P2_notify)}
+  EOF
+  require_full_window = false
+  low_count_query = "sum(last_15m):count:{{ stencil.ApplyTemplate "goPackageSafeName" }}.http_request_seconds{*, !env:development} by {kube_namespace}.as_count() < 1000"
+  low_traffic_query = "avg(last_15m):p90:{{ stencil.ApplyTemplate "goPackageSafeName" }}.http_request_seconds{*, !env:development} by {kube_namespace} > 2"
+  high_traffic_query = "avg(last_15m):p99:{{ stencil.ApplyTemplate "goPackageSafeName" }}.http_request_seconds{*, !env:development} by {kube_namespace} > 2"
+}
+
+resource "datadog_service_level_objective" "http_p99_latency" {
+  name        = "{{ .Config.Name | title }} HTTP P99 Latency"
+  type        = "monitor"
+  description = "Keeping track of P99 latency commitments for all {{ .Config.Name | title }} requests in aggregate, for production bentos only."
+  tags = local.ddTags
+  monitor_ids = [module.http_latency_high.high_traffic_id]
+  groups = [
+    {{- range $b := stencil.Arg "bentos" }}
+    "kube_namespace:{{ stencil.ApplyTemplate "goPackageSafeName" }}--{{ $b }}",
+    {{- end }}
+  ]
+  thresholds {
+    timeframe = "7d"
+    target = 99.9
+    warning = 99.95
+  }
+}
+
+resource "datadog_service_level_objective" "http_success" {
+  name        = "{{ .Config.Name | title }} HTTP Success Response"
+  type        = "metric"
+  description = "Comparing 5xx responses to all requests as a ratio, broken out by bento."
+  tags = local.ddTags
+  query {
+    numerator   = "count:{{ stencil.ApplyTemplate "goPackageSafeName" }}.http_request_seconds{!status:5xx, !env:development} by {kube_namespace}.as_count()"
+    denominator = "count:{{ stencil.ApplyTemplate "goPackageSafeName" }}.http_request_seconds{*, !env:development} by {kube_namespace}.as_count()"
+  }
+  thresholds {
+    timeframe = "7d"
+    target = 99.9
+    warning = 99.95
+  }
+}
+{{- end }}
+
+{{- if has "grpc" (stencil.Arg "serviceActivities") }}
+variable grpc_request_source {
+  type    = string
+  default = "grpc_request_handled"
+}
+
+variable grpc_tags {
+  type    = list(string)
+  default = [{{ QuoteJoinStrings (toStrings (stencil.Arg "terraform.datadog.grpc.tags")) ", " | default "\"*\", \"!env:development\"" }}]
+}
+
+variable grpc_evaluation_window {
+  type    = string
+  default = {{ stencil.Arg "terraform.datadog.grpc.evaluationWindow" | default "last_15m" | quote }}
+}
+
+variable grpc_low_count_threshold {
+  type   = number
+  default = {{ stencil.Arg "terraform.datadog.grpc.lowTrafficCountThreshold" | default 1000 }}
+}
+
+variable grpc_qos_low_traffic_threshold {
+  type    = number
+  default = {{ stencil.Arg "terraform.datadog.grpc.qos.thresholds.lowTraffic" | default 50 }}
+}
+
+variable grpc_qos_high_traffic_threshold {
+  type   = number
+  default = {{ stencil.Arg "terraform.datadog.grpc.qos.thresholds.highTraffic" | default 99 }}
+}
+
+module "grpc_success_rate_low" {
+  source = "git@github.com:getoutreach/monitoring-terraform.git//modules/alerts/datadog/low-traffic-composite-monitor"
+  name = "{{ .Config.Name | title }} GRPC Success Rate Low"
+  tags = local.ddTags
+  message = <<EOF
+  Composite monitor of GRPC QoS based on traffic
+  Calculating the success rate (!statuscategory:categoryservererror) of GRPC requests as a 0-100% monitor.
+  High traffic -> ${var.grpc_qos_high_traffic_threshold}%
+  Low traffic -> ${var.grpc_qos_low_traffic_threshold}%
+  Runbook: "https://github.com/getoutreach/{{ .Config.Name }}/blob/main/documentation/runbooks/grpc-success-rate-low.md"
+  Notify: ${join(" ", var.P2_notify)}
+  EOF
+  require_full_window = false
+  low_count_query = "sum(${var.grpc_evaluation_window}):count:{{ stencil.ApplyTemplate "goPackageSafeName" }}.${var.grpc_request_source}{${join(", ", var.grpc_tags)}} by {kube_namespace}.as_count() < ${var.grpc_low_count_threshold}"
+  low_traffic_query = "sum(${var.grpc_evaluation_window}):default_zero(100 * (count:{{ stencil.ApplyTemplate "goPackageSafeName" }}.${var.grpc_request_source}{${join(", ", var.grpc_tags)},statuscategory:categoryservererror} by {kube_namespace}.as_count() / count:{{ stencil.ApplyTemplate "goPackageSafeName" }}.${var.grpc_request_source}{${join(", ", var.grpc_tags)}} by {kube_namespace}.as_count())) >= ${var.grpc_qos_low_traffic_threshold}"
+  high_traffic_query = "sum(${var.grpc_evaluation_window}):100 * ( count:{{ stencil.ApplyTemplate "goPackageSafeName" }}.${var.grpc_request_source}{${join(", ", var.grpc_tags)}, !statuscategory:categoryservererror} by {kube_namespace}.as_count() / count:{{ stencil.ApplyTemplate "goPackageSafeName" }}.${var.grpc_request_source}{${join(", ", var.grpc_tags)}} by {kube_namespace}.as_count() ) < ${var.grpc_qos_high_traffic_threshold}"
+}
+
+variable grpc_latency_low_traffic_percentile {
+  type    = number
+  default = {{ stencil.Arg "terraform.datadog.grpc.latency.percentiles.lowTraffic" | default 90 }}
+}
+
+variable grpc_latency_high_traffic_percentile {
+  type    = number
+  default = {{ stencil.Arg "terraform.datadog.grpc.latency.percentiles.highTraffic" | default 99 }}
+}
+
+variable grpc_latency_low_traffic_threshold {
+  type    = number
+  default = {{ stencil.Arg "terraform.datadog.grpc.latency.thresholds.lowTraffic" | default 2 }}
+}
+
+variable grpc_latency_high_traffic_threshold {
+  type   = number
+  default = {{ stencil.Arg "terraform.datadog.grpc.latency.thresholds.highTraffic" | default 2 }}
+}
+
+module "grpc_latency_high" {
+  source = "git@github.com:getoutreach/monitoring-terraform.git//modules/alerts/datadog/low-traffic-composite-monitor"
+  name = "{{ .Config.Name | title }} GRPC Latency High"
+  tags = local.ddTags
+  message = <<EOF
+  Composite monitor of GRPC request latency based on traffic
+  High traffic -> P${var.grpc_latency_high_traffic_percentile}
+  Low traffic -> P${var.grpc_latency_low_traffic_percentile}
+  Runbook: "https://github.com/getoutreach/{{ .Config.Name }}/blob/main/documentation/runbooks/grpc-latency-high.md"
+  Notify: ${join(" ", var.P2_notify)}
+  EOF
+  require_full_window = false
+  low_count_query = "sum(${var.grpc_evaluation_window}):count:{{ stencil.ApplyTemplate "goPackageSafeName" }}.${var.grpc_request_source}{${join(", ", var.grpc_tags)}} by {kube_namespace}.as_count() < ${var.grpc_low_count_threshold}"
+  low_traffic_query = "avg(${var.grpc_evaluation_window}):p${var.grpc_latency_low_traffic_percentile}:{{ stencil.ApplyTemplate "goPackageSafeName" }}.${var.grpc_request_source}{${join(", ", var.grpc_tags)}} by {kube_namespace} > ${var.grpc_latency_low_traffic_threshold}"
+  high_traffic_query = "avg(${var.grpc_evaluation_window}):p${var.grpc_latency_high_traffic_percentile}:{{ stencil.ApplyTemplate "goPackageSafeName" }}.${var.grpc_request_source}{${join(", ", var.grpc_tags)}} by {kube_namespace} > ${var.grpc_latency_high_traffic_threshold}"
+}
+
+resource "datadog_service_level_objective" "grpc_p99_latency" {
+  name        = "{{ .Config.Name | title }} GRPC P99 Latency"
+  type        = "monitor"
+  description = "Keeping track of P99 latency commitments for all {{ .Config.Name | title }} GRPC requests in aggregate, for production bentos only."
+  tags = local.ddTags
+  monitor_ids = [module.grpc_latency_high.high_traffic_id]
+  groups = [
+    {{- range $b := stencil.Arg "bentos" }}
+    "kube_namespace:{{ stencil.ApplyTemplate "goPackageSafeName" }}--{{ $b }}",
+    {{- end }}
+  ]
+  thresholds {
+    timeframe = "7d"
+    target = 99.9
+    warning = 99.95
+  }
+}
+
+resource "datadog_service_level_objective" "grpc_success" {
+  name        = "{{ .Config.Name | title }} GRPC Success Response"
+  type        = "metric"
+  description = "Comparing (status:ok) responses to all requests as a ratio, broken out by bento."
+  tags = local.ddTags
+  query {
+    numerator   = "count:{{ stencil.ApplyTemplate "goPackageSafeName" }}.${var.grpc_request_source}{${join(", ", var.grpc_tags)}, !statuscategory:categoryservererror} by {kube_namespace}.as_count()"
+    denominator = "count:{{ stencil.ApplyTemplate "goPackageSafeName" }}.${var.grpc_request_source}{${join(", ", var.grpc_tags)}} by {kube_namespace}.as_count()"
+  }
+  thresholds {
+    timeframe = "7d"
+    target = 99.9
+    warning = 99.95
+  }
+}
+{{- end }}
+
+{{- if has "temporal" (stencil.Arg "serviceActivities") }}
+resource "datadog_monitor" "temporal_frontend_pod_restarts" {
+  type = "query alert"
+  name = "{{ .Config.Name | title }} Temporal Frontend Pod Restarts > 3 last 30m"
+  query = "max(last_30m):diff(sum:kubernetes_state.container.restarts{kube_container_name:temporal-frontend,kube_namespace:{{ stencil.ApplyTemplate "goPackageSafeName" }}*,!env:development} by {kube_namespace}) > 3"
+  tags = local.ddTags
+  message = <<EOF
+  If we ever have a pod restart, we want to know.
+  Note: This monitor will auto-resolve after 30 minutes of no restarts.
+  Runbook: "https://github.com/getoutreach/{{ .Config.Name }}/blob/main/documentation/runbooks/pod-restarts.md"
+  Notify: ${join(" ", var.P1_notify)}
+  EOF
+  require_full_window = false
+}
+
+resource "datadog_monitor" "temporal_worker_pod_restarts" {
+  type = "query alert"
+  name = "{{ .Config.Name | title }} Temporal Worker Pod Restarts > 3 last 30m"
+  query = "max(last_30m):diff(sum:kubernetes_state.container.restarts{kube_container_name:temporal-worker,kube_namespace:{{ stencil.ApplyTemplate "goPackageSafeName" }}*,!env:development} by {kube_namespace}) > 3"
+  tags = local.ddTags
+  message = <<EOF
+  If we ever have a pod restart, we want to know.
+  Note: This monitor will auto-resolve after 30 minutes of no restarts.
+  Runbook: "https://github.com/getoutreach/{{ .Config.Name }}/blob/main/documentation/runbooks/pod-restarts.md"
+  Notify: ${join(" ", var.P1_notify)}
+  EOF
+  require_full_window = false
+}
+
+resource "datadog_monitor" "temporal_matching_pod_restarts" {
+  type = "query alert"
+  name = "{{ .Config.Name | title }} Temporal Matching Pod Restarts > 3 last 30m"
+  query = "max(last_30m):diff(sum:kubernetes_state.container.restarts{kube_container_name:temporal-matching,kube_namespace:{{ stencil.ApplyTemplate "goPackageSafeName" }}*,!env:development} by {kube_namespace}) > 3"
+  tags = local.ddTags
+  message = <<EOF
+  If we ever have a pod restart, we want to know.
+  Note: This monitor will auto-resolve after 30 minutes of no restarts.
+  Runbook: "https://github.com/getoutreach/{{ .Config.Name }}/blob/main/documentation/runbooks/pod-restarts.md"
+  Notify: ${join(" ", var.P1_notify)}
+  EOF
+  require_full_window = false
+}
+
+resource "datadog_monitor" "temporal_history_pod_restarts" {
+  type = "query alert"
+  name = "{{ .Config.Name | title }} Temporal History Pod Restarts > 3} last 30m"
+  query = "max(last_30m):diff(sum:kubernetes_state.container.restarts{kube_container_name:temporal-history,kube_namespace:{{ stencil.ApplyTemplate "goPackageSafeName" }}*,!env:development} by {kube_namespace}) > 3"
+  tags = local.ddTags
+  message = <<EOF
+  If we ever have a pod restart, we want to know.
+  Note: This monitor will auto-resolve after 30 minutes of no restarts.
+  Runbook: "https://github.com/getoutreach/{{ .Config.Name }}/blob/main/documentation/runbooks/pod-restarts.md"
+  Notify: ${join(" ", var.P1_notify)}
+  EOF
+  require_full_window = false
+}
+
+resource "datadog_monitor" "temporal_frontend_available_pods_low" {
+  type = "query alert"
+  name = "{{ .Config.Name | title }} Available Temporal frontend Pods Low"
+  query = "max(last_10m):avg:kubernetes_state.deployment.replicas_available{deployment:temporal-frontend,kube_namespace:{{ stencil.ApplyTemplate "goPackageSafeName" }}*,env:production} by {kube_namespace} < ${var.available_pods_low_count}"
+  tags = local.ddTags
+  message = <<EOF
+  The {{ .Config.Name | title }} temporal frontend replica count should be at least ${var.available_pods_low_count}, which is also the PDB. If it's lower, that's below the PodDisruptionBudget and we're likely headed toward a total outage of {{ .Config.Name | title }}.
+  Note: This P1 alert only includes production
+  Runbook: "https://github.com/getoutreach/{{ .Config.Name }}/blob/main/documentation/runbooks/available-pods-low.md"
+  Notify: ${join(" ", var.P1_notify)}
+  EOF
+}
+
+resource "datadog_monitor" "temporal_history_available_pods_low" {
+  type = "query alert"
+  name = "{{ .Config.Name | title }} Available Temporal history Pods Low"
+  query = "max(last_10m):avg:kubernetes_state.deployment.replicas_available{deployment:temporal-history,kube_namespace:{{ stencil.ApplyTemplate "goPackageSafeName" }}*,env:production} by {kube_namespace} < ${var.available_pods_low_count}"
+  tags = local.ddTags
+  message = <<EOF
+  The {{ .Config.Name | title }} temporal history replica count should be at least ${var.available_pods_low_count}, which is also the PDB. If it's lower, that's below the PodDisruptionBudget and we're likely headed toward a total outage of {{ .Config.Name | title }}.
+  Note: This P1 alert only includes production
+  Runbook: "https://github.com/getoutreach/{{ .Config.Name }}/blob/main/documentation/runbooks/available-pods-low.md"
+  Notify: ${join(" ", var.P1_notify)}
+  EOF
+}
+
+resource "datadog_monitor" "temporal_matching_available_pods_low" {
+  type = "query alert"
+  name = "{{ .Config.Name | title }} Available Temporal matching Pods Low"
+  query = "max(last_10m):avg:kubernetes_state.deployment.replicas_available{deployment:temporal-matching,kube_namespace:{{ stencil.ApplyTemplate "goPackageSafeName" }}*,env:production} by {kube_namespace} < ${var.available_pods_low_count}"
+  tags = local.ddTags
+  message = <<EOF
+  The {{ .Config.Name | title }} temporal matching replica count should be at least ${var.available_pods_low_count}, which is also the PDB. If it's lower, that's below the PodDisruptionBudget and we're likely headed toward a total outage of {{ .Config.Name | title }}.
+  Note: This P1 alert only includes production
+  Runbook: "https://github.com/getoutreach/{{ .Config.Name }}/blob/main/documentation/runbooks/available-pods-low.md"
+  Notify: ${join(" ", var.P1_notify)}
+  EOF
+}
+
+resource "datadog_monitor" "temporal_worker_available_pods_low" {
+  type = "query alert"
+  name = "{{ .Config.Name | title }} Available Temporal worker Pods Low"
+  query = "max(last_10m):avg:kubernetes_state.deployment.replicas_available{deployment:temporal-worker,kube_namespace:{{ stencil.ApplyTemplate "goPackageSafeName" }}*,env:production} by {kube_namespace} < ${var.available_pods_low_count}"
+  tags = local.ddTags
+  message = <<EOF
+  The {{ .Config.Name | title }} temporal worker replica count should be at least ${var.available_pods_low_count}, which is also the PDB. If it's lower, that's below the PodDisruptionBudget and we're likely headed toward a total outage of {{ .Config.Name | title }}.
+  Note: This P1 alert only includes production
+  Runbook: "https://github.com/getoutreach/{{ .Config.Name }}/blob/main/documentation/runbooks/available-pods-low.md"
+  Notify: ${join(" ", var.P1_notify)}
+  EOF
+}
+{{- end }}
+
+///Block(tfCustomDatadog)
+{{ file.Block "tfCustomDatadog" }}
+///EndBlock(tfCustomDatadog)

--- a/templates/monitoring/main.tf.tpl
+++ b/templates/monitoring/main.tf.tpl
@@ -1,0 +1,25 @@
+terraform {
+  backend "s3" {
+    bucket               = "outreach-terraform"
+    dynamodb_table       = "terraform_statelock"
+    workspace_key_prefix = "terraform_workspaces"
+    #####
+    # Ensure this key is unique per project
+    #####
+    key    = "monitoring/{{ .Config.Name }}/main.tfstate"
+    region = "us-west-2"
+  }
+}
+
+provider "vault" {
+  address = "https://vault.outreach.cloud"
+}
+
+data "vault_generic_secret" "datadog" {
+  path = "deploy/datadog/alerting"
+}
+
+provider "datadog" {
+  api_key = data.vault_generic_secret.datadog.data["api_key"]
+  app_key = data.vault_generic_secret.datadog.data["app_key"]
+}

--- a/templates/monitoring/terraform.tfvars.tpl
+++ b/templates/monitoring/terraform.tfvars.tpl
@@ -1,0 +1,51 @@
+# Fill these in with DataDog users/integrations to notify
+///Block(tfNotificationPriorities)
+{{- if file.Block "tfNotificationPriorities" }}
+{{ file.Block "tfNotificationPriorities" }}
+{{- else }}
+P1_notify = []
+P2_notify = []
+{{- end }}
+///EndBlock(tfNotificationPriorities)
+
+# Fill these in with tags for your datadog dashboards/monitors
+# Team and service names will be added automatically elsewhere, add anything additional to those two in here
+///Block(tfAdditionalDdTags)
+{{- if file.Block "tfAdditionalDdTags" }}
+{{ file.Block "tfAdditionalDdTags" }}
+{{- else }}
+additional_dd_tags = []
+{{- end }}
+///EndBlock(tfAdditionalDdTags)
+
+# Replace the following values with adequate yellow/red
+# thresholds for your service call latencies
+#
+# Note that threshold affect presentation of Performance charts
+# and not used for monitors/alerts
+///Block(tfLatencyThresholdsMs)
+{{- if file.Block "tfLatencyThresholdsMs" }}
+{{ file.Block "tfLatencyThresholdsMs" }}
+{{- else }}
+Latency_red_line_ms    = 500
+Latency_yellow_line_ms = 200
+{{- end }}
+///EndBlock(tfLatencyThresholdsMs)
+
+# Replace the following values with adequate yellow/red
+# thresholds (in percentage) for your service call latencies
+#
+# Note that threshold affect presentation of QoS charts
+# and not used for monitors/alerts
+///Block(tfLatencyThresholdsPercentage)
+{{- if file.Block "tfLatencyThresholdsPercentage" }}
+{{ file.Block "tfLatencyThresholdsPercentage" }}
+{{- else }}
+Qos_red_line    = 98
+Qos_yellow_line = 99
+{{- end }}
+///EndBlock(tfLatencyThresholdsPercentage)
+
+///Block(tfCustomVars)
+{{ file.Block "tfCustomVars" }}
+///EndBlock(tfCustomVars)

--- a/templates/monitoring/versions.tf.tpl
+++ b/templates/monitoring/versions.tf.tpl
@@ -1,0 +1,15 @@
+terraform {
+  # This is a top-level project, so we pin to specific versions.  All child
+  # modules should use versions ">=" version specifiers for maximum flexibility.
+  required_providers {
+    datadog = {
+      source  = "datadog/datadog"
+      version = ">= 2.20.0"
+    }
+    vault = {
+      source = "hashicorp/vault"
+      version = ">= 2.15.0"
+    }
+  }
+  required_version = ">= 0.13"
+}


### PR DESCRIPTION
<!--
  !!!! README !!!! Please fill this out.

  Please follow the PR naming conventions:
  https://outreach-io.atlassian.net/wiki/spaces/EN/pages/1902444645/Conventional+Commits
-->

<!-- A short description of what your PR does and what it solves. -->

## What this PR does / why we need it

Migrates the monitoring terraform templates from bootstrap. This is needed before we add OpenTelemetry support to the automatically generated alerts and dashboards.

<!--- Block(jiraPrefix) --->

## Jira ID

[DTSS-1911]

<!--- EndBlock(jiraPrefix) --->

<!-- Notes that may be helpful for anyone reviewing this PR -->

## Notes for your reviewers

<!--- Block(custom) -->

<!--- EndBlock(custom) -->


[DTSS-1911]: https://outreach-io.atlassian.net/browse/DTSS-1911?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ