### PR TITLE
fix: remove unused import from main_cli causing bootstrap v10 to fail

### DIFF
--- a/templates/cmd/main_cli.go.tpl
+++ b/templates/cmd/main_cli.go.tpl
@@ -13,7 +13,6 @@ import (
 	"context"
 
 	oapp "github.com/getoutreach/gobox/pkg/app"
-	"github.com/getoutreach/gobox/pkg/exec"
 	"github.com/sirupsen/logrus"
 	gcli "github.com/getoutreach/gobox/pkg/cli"
 	"github.com/urfave/cli/v2"


### PR DESCRIPTION
<!--
  !!!! README !!!! Please fill this out.

  Please follow the PR naming conventions:
  https://outreach-io.atlassian.net/wiki/spaces/EN/pages/1902444645/Conventional+Commits
-->

<!-- A short description of what your PR does and what it solves. -->

## What this PR does / why we need it
This PR removes unused import from main_cli.go template.

Running bootstrap on the smartstore repo (lib only) fails with: 
```
ruby 2.6.6 is already installed
terraform 0.13.5 is already installed
INFO[0021]  - go mod tidy                               
INFO[0023]  - Format Files                              
 :: Running gogenerate
# github.com/getoutreach/smartstore/cmd/smartstore
../../cmd/smartstore/smartstore.go:13:2: imported and not used: "github.com/getoutreach/gobox/pkg/exec"
internal/pgtest/generate.go:7: running "go": exit status 2
make: *** [gogenerate] Error 1
ERRO[0036] failed to run: run codegen: failed to run post run command for module "github.com/getoutreach/stencil-base": exit status 2 
ERRO[0045] failed to run: failed to run stencil: exit status 1 
```
<!--- Block(jiraPrefix) --->

## Jira ID

[DTSS-00]

<!--- EndBlock(jiraPrefix) --->

<!-- Notes that may be helpful for anyone reviewing this PR -->

## Notes for your reviewers

<!--- Block(custom) -->

<!--- EndBlock(custom) -->
