### PR TITLE
fix: issue with older version of eslint parser

### DIFF
--- a/templates/_helpers.tpl
+++ b/templates/_helpers.tpl
@@ -181,7 +181,7 @@ nodejs:
   - name: "@typescript-eslint/eslint-plugin"
     version: ^2.33.0
   - name: "@typescript-eslint/parser"
-    version: ^2.33.0
+    version: ^4.1.1
   - name: eslint
     version: ^7.13.0
   - name: eslint-config-prettier


### PR DESCRIPTION
[DTSS-1849](https://outreach-io.atlassian.net/browse/DTSS-1849) - eslint is breaking on some authz code because it is using a fairly old eslint parser version. This upgrades the version which should unblock authz from bootstrapping. 