### PR TITLE
feat(vscode): default formatter for markdown to prettier

### DIFF
--- a/templates/.vscode/extensions.json.tpl
+++ b/templates/.vscode/extensions.json.tpl
@@ -1,6 +1,7 @@
 {
   "recommendations": [
     "editorconfig.editorconfig",
+    "esbenp.prettier-vscode",
     "hashicorp.terraform",
     "golang.go",
     "heptio.jsonnet",

--- a/templates/.vscode/settings.json.tpl
+++ b/templates/.vscode/settings.json.tpl
@@ -27,6 +27,9 @@
   "[dockerfile]": {
     "editor.defaultFormatter": "ms-azuretools.vscode-docker"
   },
+  "[markdown]": {
+    "editor.defaultFormatter": "esbenp.prettier-vscode",
+  },
   "[proto3]": {
     "editor.defaultFormatter": "zxh404.vscode-proto3"
   },


### PR DESCRIPTION
## What this PR does / why we need it

Adds the [popular prettier extension to VSCode](https://marketplace.visualstudio.com/items?itemName=esbenp.prettier-vscode) so that Markdown files get autoformatted on save.

## Jira ID

[DTSS-2081]

## Notes for your reviewers

Please note that this does not resolve DTSS-2081, but rather works around it if DTSS decides to temporarily remove Markdown formatting support from Stencil while they don't have bandwidth to work on the bug I reported.


[DTSS-2081]: https://outreach-io.atlassian.net/browse/DTSS-2081?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ