### PR TITLE
fix: return use of dynamic org from box config

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,7 +1,7 @@
 # Please re-run stencil after any changes to this file.
 version: 2.1
 orbs:
-  shared: getoutreach/shared@1.60.0
+  shared: getoutreach/shared@2.2.0
 
 # Extra contexts to expose to all jobs below
 contexts: &contexts

--- a/bootstrap.lock
+++ b/bootstrap.lock
@@ -1,4 +1,4 @@
 versions:
   # HACK(jaredallard): Remove when stencil-base is cleaned up and bootstrap
   # is dead.
-  devbase: v1.60.0
+  devbase: v2.2.0

--- a/templates/_helpers.tpl
+++ b/templates/_helpers.tpl
@@ -73,13 +73,9 @@
 {{- printf "Copyright %s Outreach Corporation. All Rights Reserved." (stencil.ApplyTemplate "currentYear") }}
 {{- end }}
 
-# Returns the import path for this application. Right now, it hardcodes the Org
-# to be "getoutreach" because using .Runtime.Box.Org requires a file
-# "$HOME/.outreach/.config/box" to have a '.config.org' of "getoutreach", a
-# piece of state which is not there in our CI environments, so will always be
-# "", causing this to always render incorrectly in CI.
+# Returns the import path for this application.
 {{- define "appImportPath" }}
-{{- list "github.com" "getoutreach" .Config.Name | join "/" }}
+{{- list "github.com" .Runtime.Box.Org .Config.Name | join "/" }}
 {{- end }}
 
 # Service names may have hyphens in them, but Golang structs and Protobuf


### PR DESCRIPTION
<!--
  !!!! README !!!! Please fill this out.

  Please follow the PR naming conventions:
  https://outreach-io.atlassian.net/wiki/spaces/EN/pages/1902444645/Conventional+Commits
-->

<!-- A short description of what your PR does and what it solves. -->

## What this PR does / why we need it

This change restores the behavior of the basing the appImportPath on the `box` configuration. The behavior was changed in https://github.com/getoutreach/stencil-golang/pull/34/files This restores the original behavior.

<!--- Block(jiraPrefix) --->

## Jira ID

[DT-2170]
<!--- EndBlock(jiraPrefix) --->

<!-- Notes that may be helpful for anyone reviewing this PR -->

## Notes for your reviewers

<!--- Block(custom) -->

<!--- EndBlock(custom) -->


[DT-2170]: https://outreach-io.atlassian.net/browse/DT-2170?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ