### PR TITLE
fix(docker): generate docker.yaml only if a service

### DIFF
--- a/manifest.yaml
+++ b/manifest.yaml
@@ -123,7 +123,7 @@ arguments:
     description: Overrides the low traffic threshold in the "http_success_rate_low" terraform module in monitoring/datadog.tf.
   terraform.datadog.http.thresholds.highTraffic:
     schema:
-      type:  integer
+      type: integer
     description: Overrides the high traffic threshold in the "http_success_rate_low" terraform module in monitoring/datadog.tf.
   terraform.datadog.pods.thresholds.availableLowCount:
     schema:

--- a/templates/deployments/docker.yaml.tpl
+++ b/templates/deployments/docker.yaml.tpl
@@ -1,3 +1,4 @@
+{{- $_ := stencil.ApplyTemplate "skipIfNotService" -}}
 {{ .Config.Name }}:
 ###Block(customDockerImages)
 {{ file.Block "customDockerImages" }}


### PR DESCRIPTION
<!--
  !!!! README !!!! Please fill this out.

  Please follow the PR naming conventions:
  https://outreach-io.atlassian.net/wiki/spaces/EN/pages/1902444645/Conventional+Commits
-->

<!-- A short description of what your PR does and what it solves. -->

## What this PR does / why we need it
Title says, it does. This PR technically breaks `customDockerfile`, but I don't think there's really a good path-forward for that argument anyways. Instead, the user should create `deployments/docker.yaml` as needed for their custom dockerfiles.

When this is going to go out we should probably do that [for users of `customDockerfile`](https://cs.github.com/?scopeName=All+repos&scope=&q=org%3Agetoutreach+%22customDockerfile%3A+true%22).
<!--- Block(jiraPrefix) --->

## Jira ID

[XX-XX]

<!--- EndBlock(jiraPrefix) --->

<!-- Notes that may be helpful for anyone reviewing this PR -->

## Notes for your reviewers

PRs:

 * https://github.com/getoutreach/flubby/pull/90
 * https://github.com/getoutreach/smartstore/pull/130

<!--- Block(custom) -->

<!--- EndBlock(custom) -->
