### PR TITLE
feat: support otel for monitoring

### DIFF
--- a/manifest.yaml
+++ b/manifest.yaml
@@ -64,6 +64,7 @@ arguments:
       enum:
         - datadog
         - opentelemetry
+        - dual
     description: Metrics collector to use (supports opentelemetry and datadog)
     default: datadog
   tracing:

--- a/templates/monitoring/dashboard.tf.tpl
+++ b/templates/monitoring/dashboard.tf.tpl
@@ -124,13 +124,13 @@ locals {
 # - RPM, timeseries
 
 module "grpc_load" {
-  source     = "../../bootstrap-terraform/monitoring/datadog/section/grpc/load"
+  source     = "git@github.com:getoutreach/bootstrap-terraform.git//monitoring/datadog/section/grpc/load?ref=v1.3.0"
   deployment = "{{ $deployment }}"
 	prefix     = local.prefix
 }
 {{- if eq "dual" (stencil.Arg "metrics") }}
 module "grpc_load_otel" {
-  source     = "../../bootstrap-terraform/monitoring/datadog/section/grpc/load"
+  source     = "git@github.com:getoutreach/bootstrap-terraform.git//monitoring/datadog/section/grpc/load?ref=v1.3.0"
   deployment = "{{ $deployment }}"
 	prefix     = false
 }
@@ -163,13 +163,13 @@ variable Latency_yellow_line_ms {
 }
 
 module "grpc_performance" {
-  source     = "../../bootstrap-terraform/monitoring/datadog/section/grpc/perf"
+  source     = "git@github.com:getoutreach/bootstrap-terraform.git//monitoring/datadog/section/grpc/load?ref=v1.3.0"
   deployment = "{{ $deployment }}"
 	prefix     = local.prefix
 }
 {{- if eq "dual" (stencil.Arg "metrics") }}
 module "grpc_performance_otel" {
-  source     = "../../bootstrap-terraform/monitoring/datadog/section/grpc/perf"
+  source     = "git@github.com:getoutreach/bootstrap-terraform.git//monitoring/datadog/section/grpc/load?ref=v1.3.0"
   deployment = "{{ $deployment }}"
 	prefix     = false
 }
@@ -201,13 +201,13 @@ variable Qos_yellow_line {
 }
 
 module "grpc_qos" {
-  source     = "../../bootstrap-terraform/monitoring/datadog/section/grpc/qos"
+  source     = "git@github.com:getoutreach/bootstrap-terraform.git//monitoring/datadog/section/grpc/load?ref=v1.3.0"
   deployment = "{{ $deployment }}"
 	prefix     = local.prefix
 }
 {{- if eq "dual" (stencil.Arg "metrics") }}
 module "grpc_qos_otel" {
-  source     = "../../bootstrap-terraform/monitoring/datadog/section/grpc/qos"
+  source     = "git@github.com:getoutreach/bootstrap-terraform.git//monitoring/datadog/section/grpc/load?ref=v1.3.0"
   deployment = "{{ $deployment }}"
 	prefix     = false
 }
@@ -218,13 +218,13 @@ module "grpc_qos_otel" {
 # reported in the past.
 
 module "grpc_bento_activity" {
-  source     = "../../bootstrap-terraform/monitoring/datadog/section/grpc/activity"
+  source     = "git@github.com:getoutreach/bootstrap-terraform.git//monitoring/datadog/section/grpc/load?ref=v1.3.0"
   deployment = "{{ $deployment }}"
 	prefix     = local.prefix
 }
 {{- if eq "dual" (stencil.Arg "metrics") }}
 module "grpc_bento_activity_otel" {
-  source     = "../../bootstrap-terraform/monitoring/datadog/section/grpc/activity"
+  source     = "git@github.com:getoutreach/bootstrap-terraform.git//monitoring/datadog/section/grpc/load?ref=v1.3.0"
   deployment = "{{ $deployment }}"
 	prefix     = false
 }
@@ -233,51 +233,51 @@ module "grpc_bento_activity_otel" {
 
 {{- if has "temporal" (stencil.Arg "serviceActivities") }}
 module "temporal_qos" {
-  source     = "../../bootstrap-terraform/monitoring/datadog/section/temporal/qos"
+  source     = "git@github.com:getoutreach/bootstrap-terraform.git//monitoring/datadog/section/grpc/load?ref=v1.3.0"
   deployment = "{{ $deployment }}"
 	prefix     = local.prefix
 }
 {{- if eq "dual" (stencil.Arg "metrics") }}
 module "temporal_qos_otel" {
-  source     = "../../bootstrap-terraform/monitoring/datadog/section/temporal/qos"
+  source     = "git@github.com:getoutreach/bootstrap-terraform.git//monitoring/datadog/section/grpc/load?ref=v1.3.0"
   deployment = "{{ $deployment }}"
 	prefix     = false
 }
 {{- end }}
 
 module "temporal_activity" {
-  source     = "../../bootstrap-terraform/monitoring/datadog/section/temporal/activity"
+  source     = "git@github.com:getoutreach/bootstrap-terraform.git//monitoring/datadog/section/grpc/load?ref=v1.3.0"
   deployment = "{{ $deployment }}"
 	prefix     = local.prefix
 }
 {{- if eq "dual" (stencil.Arg "metrics") }}
 module "temporal_activity_otel" {
-  source     = "../../bootstrap-terraform/monitoring/datadog/section/temporal/activity"
+  source     = "git@github.com:getoutreach/bootstrap-terraform.git//monitoring/datadog/section/grpc/load?ref=v1.3.0"
   deployment = "{{ $deployment }}"
 	prefix     = false
 }
 {{- end }}
 
 module "temporal_latency" {
-  source     = "../../bootstrap-terraform/monitoring/datadog/section/temporal/latency"
+  source     = "git@github.com:getoutreach/bootstrap-terraform.git//monitoring/datadog/section/grpc/load?ref=v1.3.0"
   deployment = "{{ $deployment }}"
 }
 
 module "temporal_workflow" {
-  source     = "../../bootstrap-terraform/monitoring/datadog/section/temporal/workflow"
+  source     = "git@github.com:getoutreach/bootstrap-terraform.git//monitoring/datadog/section/grpc/load?ref=v1.3.0"
   deployment = "{{ $deployment }}"
 	prefix     = local.prefix
 }
 {{- if eq "dual" (stencil.Arg "metrics") }}
 module "temporal_workflow_otel" {
-  source     = "../../bootstrap-terraform/monitoring/datadog/section/temporal/workflow"
+  source     = "git@github.com:getoutreach/bootstrap-terraform.git//monitoring/datadog/section/grpc/load?ref=v1.3.0"
   deployment = "{{ $deployment }}"
 	prefix     = false
 }
 {{- end }}
 
 module "temporal_resources" {
-  source     = "../../bootstrap-terraform/monitoring/datadog/section/temporal/resources"
+  source     = "git@github.com:getoutreach/bootstrap-terraform.git//monitoring/datadog/section/grpc/load?ref=v1.3.0"
   deployment = "{{ $deployment }}"
 }
 {{- end }}


### PR DESCRIPTION
<!--
  !!!! README !!!! Please fill this out.

  Please follow the PR naming conventions:
  https://outreach-io.atlassian.net/wiki/spaces/EN/pages/1902444645/Conventional+Commits
-->

<!-- A short description of what your PR does and what it solves. -->

## What this PR does / why we need it

Adds support for `datadog`, `opentelemetry`, or `dual` metrics and monitoring.

### datadog
- Only uses the datadog scraper
- Spins up a single dashboard for datadog metrics
- Uses datadog style metrics for monitoring

### optentelemetry
- Only uses the otel scraper
- Spins up a single dashboard for otel metrics
- Uses otel style metrics for monitoring

### dual
- Uses both otel and datadog scraper
- Spins up two dashboard, one for datadog and one for otel
- Uses datadog style metrics for monitoring

<!--- Block(jiraPrefix) --->

## Jira ID

[DT-1833]
[DT-1910]
<!--- EndBlock(jiraPrefix) --->

<!-- Notes that may be helpful for anyone reviewing this PR -->

## Notes for your reviewers

<!--- Block(custom) -->

<!--- EndBlock(custom) -->


[DT-1833]: https://outreach-io.atlassian.net/browse/DT-1833?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[DT-1910]: https://outreach-io.atlassian.net/browse/DT-1910?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ