### PR TITLE
fix: use cpu limits not requests for monitor

### DIFF
--- a/templates/monitoring/datadog.tf.tpl
+++ b/templates/monitoring/datadog.tf.tpl
@@ -72,7 +72,7 @@ resource "datadog_monitor" "pod_restarts_high" {
 resource "datadog_monitor" "pod_cpu_high" {
   type = "query alert"
   name = "{{ .Config.Name | title }} Pod CPU > ${var.cpu_high_threshold}% of request last ${var.cpu_high_window}m"
-  query = "avg(last_${var.cpu_high_window}m):100 * (default_zero(avg:kubernetes.cpu.usage.total{app:{{ .Config.Name }},!env:development} by {kube_namespace,pod_name}) / 1000000000) / avg:kubernetes.cpu.requests{app:{{ .Config.Name }},!env:development} by {kube_namespace} >= ${var.cpu_high_threshold}"
+  query = "avg(last_${var.cpu_high_window}m):100 * (default_zero(avg:kubernetes.cpu.usage.total{app:{{ .Config.Name }},!env:development} by {kube_namespace,pod_name}) / 1000000000) / avg:kubernetes.cpu.limits{app:{{ .Config.Name }},!env:development} by {kube_namespace} >= ${var.cpu_high_threshold}"
   tags = local.ddTags
   message = <<EOF
   One of the service's pods has been using over ${var.cpu_high_threshold}% of its requested CPU on average for the last ${var.cpu_high_window} minutes.  This almost certainly means that the service needs more CPU to function properly and is being throttled in its current form.


### PR DESCRIPTION
* everything else uses limits and using requests only makes sense
  if requests == limits

<!--
  !!!! README !!!! Please fill this out.

  Please follow the PR naming conventions:
  https://outreach-io.atlassian.net/wiki/spaces/EN/pages/1902444645/Conventional+Commits
-->

<!-- A short description of what your PR does and what it solves. -->

## What this PR does / why we need it

<!--- Block(jiraPrefix) --->

## Jira ID

[XX-XX]

<!--- EndBlock(jiraPrefix) --->

<!-- Notes that may be helpful for anyone reviewing this PR -->

## Notes for your reviewers

<!--- Block(custom) -->

<!--- EndBlock(custom) -->
