### PR TITLE
fix(jsonnet): missing semicolon

### DIFF
--- a/templates/.snapshots/TestRenderDeploymentConfig-deployments-appname-app.config.jsonnet.tpl-deployments-testing-app.config.jsonnet.snapshot
+++ b/templates/.snapshots/TestRenderDeploymentConfig-deployments-appname-app.config.jsonnet.tpl-deployments-testing-app.config.jsonnet.snapshot
@@ -70,7 +70,7 @@ local configMixins = [
 
 // config merges the mixins together, and then merges the configurationOverride ontop.
 // then env_config is merged ontop, with bento being merged last. The final result is then returned.
-local config = (std.foldl(function(x, y) (x + y), configMixins, {}) + configurationOverride)
+local config = (std.foldl(function(x, y) (x + y), configMixins, {}) + configurationOverride);
 local env_config = if std.objectHas(config.environment, app.environment) then config.environment[app.environment] else {};
 local bento_config = if std.objectHas(config.bento, app.bento) then config.bento[app.bento] else {};
 

--- a/templates/deployments/appname/app.config.jsonnet.tpl
+++ b/templates/deployments/appname/app.config.jsonnet.tpl
@@ -90,7 +90,7 @@ local configMixins = [
 
 // config merges the mixins together, and then merges the configurationOverride ontop.
 // then env_config is merged ontop, with bento being merged last. The final result is then returned.
-local config = (std.foldl(function(x, y) (x + y), configMixins, {}) + configurationOverride)
+local config = (std.foldl(function(x, y) (x + y), configMixins, {}) + configurationOverride);
 local env_config = if std.objectHas(config.environment, app.environment) then config.environment[app.environment] else {};
 local bento_config = if std.objectHas(config.bento, app.bento) then config.bento[app.bento] else {};
 


### PR DESCRIPTION
<!--
  !!!! README !!!! Please fill this out.

  Please follow the PR naming conventions:
  https://outreach-io.atlassian.net/wiki/spaces/EN/pages/1902444645/Conventional+Commits
-->

<!-- A short description of what your PR does and what it solves. -->

## What this PR does / why we need it

- jsonnetfmt doesn't like to be missing this semicolon

```
    -> jsonnetfmt (.jsonnet/.libsonnet)
./deployments/smartstorecdctestconsumer/app.config.jsonnet:78:1-6 Expected , or ; but got "local"
make: *** [fmt] Error 1
ERRO[0253] failed to run: run codegen: failed to run post run command for module "github.com/getoutreach/stencil-base": exit status 2
ERRO[0259] failed to run: failed to run stencil: exit status 1
```

<!--- Block(jiraPrefix) --->

## Jira ID

[XX-XX]

<!--- EndBlock(jiraPrefix) --->

<!-- Notes that may be helpful for anyone reviewing this PR -->

## Notes for your reviewers

<!--- Block(custom) -->

<!--- EndBlock(custom) -->
