### PR TITLE
fix(dependabot): change tabs to spaces

### DIFF
--- a/templates/.github/dependabot.yml.tpl
+++ b/templates/.github/dependabot.yml.tpl
@@ -5,11 +5,11 @@ updates:
   - package-ecosystem: "gomod"
     directory: "/"
     schedule:
-    interval: "daily"
+      interval: "daily"
     # stencil-golang managed dependencies
     ignore:
 {{- range $d := $deps.go }}
-	- dependency-name: {{ $d.name }}
+      - dependency-name: {{ $d.name }}
 {{- end }}
 
   # Ignore semantic-release, this code is only executed in CI.
@@ -18,7 +18,7 @@ updates:
     schedule:
       interval: "daily"
     ignore:
-    - dependency-name: "*"
+      - dependency-name: "*"
 
 {{- if and (has "grpc" (stencil.Arg "serviceActivities")) (has "node" (stencil.Arg "grpcClients")) }}
   # Node client for gRPC services
@@ -29,7 +29,7 @@ updates:
     # stencil-golang managed dependencies
     ignore:
 {{- range $d := (concat $deps.nodejs.dependencies $deps.nodejs.devDependencies) }}
-    - dependency-name: {{ $d.name | quote }}
+      - dependency-name: {{ $d.name | quote }}
 {{- end }}
 {{- end }}
 

--- a/templates/.github/dependabot.yml.tpl
+++ b/templates/.github/dependabot.yml.tpl
@@ -1,38 +1,38 @@
 {{- $deps := stencil.ApplyTemplate "dependencies" | fromYaml }}
 version: 2
 updates:
-	# Golang dependencies
-	- package-ecosystem: "gomod"
-		directory: "/"
-		schedule:
-			interval: "daily"
-		# stencil-golang managed dependencies
-		ignore:
+  # Golang dependencies
+  - package-ecosystem: "gomod"
+    directory: "/"
+    schedule:
+    interval: "daily"
+    # stencil-golang managed dependencies
+    ignore:
 {{- range $d := $deps.go }}
-		- dependency-name: {{ $d.name }}
+	- dependency-name: {{ $d.name }}
 {{- end }}
 
-	# Ignore semantic-release, this code is only executed in CI.
-	- package-ecosystem: "npm"
-		directory: "/"
-		schedule:
-			interval: "daily"
-		ignore:
-			- dependency-name: "*"
+  # Ignore semantic-release, this code is only executed in CI.
+  - package-ecosystem: "npm"
+    directory: "/"
+    schedule:
+      interval: "daily"
+    ignore:
+    - dependency-name: "*"
 
 {{- if and (has "grpc" (stencil.Arg "serviceActivities")) (has "node" (stencil.Arg "grpcClients")) }}
-	# Node client for gRPC services
-	- package-ecosystem: "npm"
-		directory: "/api/clients/node"
-		schedule:
-			interval: "daily"
-		# stencil-golang managed dependencies
-		ignore:
+  # Node client for gRPC services
+  - package-ecosystem: "npm"
+    directory: "/api/clients/node"
+    schedule:
+      interval: "daily"
+    # stencil-golang managed dependencies
+    ignore:
 {{- range $d := (concat $deps.nodejs.dependencies $deps.nodejs.devDependencies) }}
-		- dependency-name: {{ $d.name | quote }}
+    - dependency-name: {{ $d.name | quote }}
 {{- end }}
 {{- end }}
 
-	###Block(dependabotPackageManagers)
+  ###Block(dependabotPackageManagers)
 {{ file.Block "dependabotPackageManagers" }}
-	###EndBlock(dependabotPackageManagers)
+  ###EndBlock(dependabotPackageManagers)

--- a/templates/.snapshots/TestRenderDependabot-.github-dependabot.yml.tpl-.github-dependabot.yml.snapshot
+++ b/templates/.snapshots/TestRenderDependabot-.github-dependabot.yml.tpl-.github-dependabot.yml.snapshot
@@ -8,14 +8,14 @@ updates:
       interval: "daily"
     # stencil-golang managed dependencies
     ignore:
-    - dependency-name: github.com/getoutreach/gobox
-    - dependency-name: github.com/getoutreach/mint
-    - dependency-name: github.com/getoutreach/httpx
-    - dependency-name: github.com/getoutreach/services
-    - dependency-name: github.com/getoutreach/datastores/v2
-    - dependency-name: github.com/getoutreach/tollmon
-    - dependency-name: google.golang.org/grpc
-    - dependency-name: github.com/getoutreach/orgservice
+      - dependency-name: github.com/getoutreach/gobox
+      - dependency-name: github.com/getoutreach/mint
+      - dependency-name: github.com/getoutreach/httpx
+      - dependency-name: github.com/getoutreach/services
+      - dependency-name: github.com/getoutreach/datastores/v2
+      - dependency-name: github.com/getoutreach/tollmon
+      - dependency-name: google.golang.org/grpc
+      - dependency-name: github.com/getoutreach/orgservice
 
   # Ignore semantic-release, this code is only executed in CI.
   - package-ecosystem: "npm"
@@ -31,36 +31,36 @@ updates:
       interval: "daily"
     # stencil-golang managed dependencies
     ignore:
-    - dependency-name: "@grpc/grpc-js"
-    - dependency-name: "@grpc/proto-loader"
-    - dependency-name: "@outreach/grpc-client"
-    - dependency-name: "@outreach/find"
-    - dependency-name: "@types/google-protobuf"
-    - dependency-name: "google-protobuf"
-    - dependency-name: "ts-enum-util"
-    - dependency-name: "winston"
-    - dependency-name: "@outreach/eslint-config"
-    - dependency-name: "@outreach/prettier-config"
-    - dependency-name: "@types/jest"
-    - dependency-name: "@typescript-eslint/eslint-plugin"
-    - dependency-name: "@typescript-eslint/parser"
-    - dependency-name: "eslint"
-    - dependency-name: "eslint-config-prettier"
-    - dependency-name: "eslint-plugin-jest"
-    - dependency-name: "eslint-plugin-jsdoc"
-    - dependency-name: "eslint-plugin-lodash"
-    - dependency-name: "eslint-plugin-node"
-    - dependency-name: "grpc-tools"
-    - dependency-name: "grpc_tools_node_protoc_ts"
-    - dependency-name: "jest"
-    - dependency-name: "npm-run-all"
-    - dependency-name: "prettier"
-    - dependency-name: "rimraf"
-    - dependency-name: "ts-jest"
-    - dependency-name: "ts-node"
-    - dependency-name: "tsconfig-paths"
-    - dependency-name: "typescript"
-    - dependency-name: "wait-on"
+      - dependency-name: "@grpc/grpc-js"
+      - dependency-name: "@grpc/proto-loader"
+      - dependency-name: "@outreach/grpc-client"
+      - dependency-name: "@outreach/find"
+      - dependency-name: "@types/google-protobuf"
+      - dependency-name: "google-protobuf"
+      - dependency-name: "ts-enum-util"
+      - dependency-name: "winston"
+      - dependency-name: "@outreach/eslint-config"
+      - dependency-name: "@outreach/prettier-config"
+      - dependency-name: "@types/jest"
+      - dependency-name: "@typescript-eslint/eslint-plugin"
+      - dependency-name: "@typescript-eslint/parser"
+      - dependency-name: "eslint"
+      - dependency-name: "eslint-config-prettier"
+      - dependency-name: "eslint-plugin-jest"
+      - dependency-name: "eslint-plugin-jsdoc"
+      - dependency-name: "eslint-plugin-lodash"
+      - dependency-name: "eslint-plugin-node"
+      - dependency-name: "grpc-tools"
+      - dependency-name: "grpc_tools_node_protoc_ts"
+      - dependency-name: "jest"
+      - dependency-name: "npm-run-all"
+      - dependency-name: "prettier"
+      - dependency-name: "rimraf"
+      - dependency-name: "ts-jest"
+      - dependency-name: "ts-node"
+      - dependency-name: "tsconfig-paths"
+      - dependency-name: "typescript"
+      - dependency-name: "wait-on"
 
   ###Block(dependabotPackageManagers)
 

--- a/templates/.snapshots/TestRenderDependabot-.github-dependabot.yml.tpl-.github-dependabot.yml.snapshot
+++ b/templates/.snapshots/TestRenderDependabot-.github-dependabot.yml.tpl-.github-dependabot.yml.snapshot
@@ -1,68 +1,68 @@
 (*codegen.File)(
 version: 2
 updates:
-	# Golang dependencies
-	- package-ecosystem: "gomod"
-		directory: "/"
-		schedule:
-			interval: "daily"
-		# stencil-golang managed dependencies
-		ignore:
-		- dependency-name: github.com/getoutreach/gobox
-		- dependency-name: github.com/getoutreach/mint
-		- dependency-name: github.com/getoutreach/httpx
-		- dependency-name: github.com/getoutreach/services
-		- dependency-name: github.com/getoutreach/datastores/v2
-		- dependency-name: github.com/getoutreach/tollmon
-		- dependency-name: google.golang.org/grpc
-		- dependency-name: github.com/getoutreach/orgservice
+  # Golang dependencies
+  - package-ecosystem: "gomod"
+    directory: "/"
+    schedule:
+      interval: "daily"
+    # stencil-golang managed dependencies
+    ignore:
+    - dependency-name: github.com/getoutreach/gobox
+    - dependency-name: github.com/getoutreach/mint
+    - dependency-name: github.com/getoutreach/httpx
+    - dependency-name: github.com/getoutreach/services
+    - dependency-name: github.com/getoutreach/datastores/v2
+    - dependency-name: github.com/getoutreach/tollmon
+    - dependency-name: google.golang.org/grpc
+    - dependency-name: github.com/getoutreach/orgservice
 
-	# Ignore semantic-release, this code is only executed in CI.
-	- package-ecosystem: "npm"
-		directory: "/"
-		schedule:
-			interval: "daily"
-		ignore:
-			- dependency-name: "*"
-	# Node client for gRPC services
-	- package-ecosystem: "npm"
-		directory: "/api/clients/node"
-		schedule:
-			interval: "daily"
-		# stencil-golang managed dependencies
-		ignore:
-		- dependency-name: "@grpc/grpc-js"
-		- dependency-name: "@grpc/proto-loader"
-		- dependency-name: "@outreach/grpc-client"
-		- dependency-name: "@outreach/find"
-		- dependency-name: "@types/google-protobuf"
-		- dependency-name: "google-protobuf"
-		- dependency-name: "ts-enum-util"
-		- dependency-name: "winston"
-		- dependency-name: "@outreach/eslint-config"
-		- dependency-name: "@outreach/prettier-config"
-		- dependency-name: "@types/jest"
-		- dependency-name: "@typescript-eslint/eslint-plugin"
-		- dependency-name: "@typescript-eslint/parser"
-		- dependency-name: "eslint"
-		- dependency-name: "eslint-config-prettier"
-		- dependency-name: "eslint-plugin-jest"
-		- dependency-name: "eslint-plugin-jsdoc"
-		- dependency-name: "eslint-plugin-lodash"
-		- dependency-name: "eslint-plugin-node"
-		- dependency-name: "grpc-tools"
-		- dependency-name: "grpc_tools_node_protoc_ts"
-		- dependency-name: "jest"
-		- dependency-name: "npm-run-all"
-		- dependency-name: "prettier"
-		- dependency-name: "rimraf"
-		- dependency-name: "ts-jest"
-		- dependency-name: "ts-node"
-		- dependency-name: "tsconfig-paths"
-		- dependency-name: "typescript"
-		- dependency-name: "wait-on"
+  # Ignore semantic-release, this code is only executed in CI.
+  - package-ecosystem: "npm"
+    directory: "/"
+    schedule:
+      interval: "daily"
+    ignore:
+      - dependency-name: "*"
+  # Node client for gRPC services
+  - package-ecosystem: "npm"
+    directory: "/api/clients/node"
+    schedule:
+      interval: "daily"
+    # stencil-golang managed dependencies
+    ignore:
+    - dependency-name: "@grpc/grpc-js"
+    - dependency-name: "@grpc/proto-loader"
+    - dependency-name: "@outreach/grpc-client"
+    - dependency-name: "@outreach/find"
+    - dependency-name: "@types/google-protobuf"
+    - dependency-name: "google-protobuf"
+    - dependency-name: "ts-enum-util"
+    - dependency-name: "winston"
+    - dependency-name: "@outreach/eslint-config"
+    - dependency-name: "@outreach/prettier-config"
+    - dependency-name: "@types/jest"
+    - dependency-name: "@typescript-eslint/eslint-plugin"
+    - dependency-name: "@typescript-eslint/parser"
+    - dependency-name: "eslint"
+    - dependency-name: "eslint-config-prettier"
+    - dependency-name: "eslint-plugin-jest"
+    - dependency-name: "eslint-plugin-jsdoc"
+    - dependency-name: "eslint-plugin-lodash"
+    - dependency-name: "eslint-plugin-node"
+    - dependency-name: "grpc-tools"
+    - dependency-name: "grpc_tools_node_protoc_ts"
+    - dependency-name: "jest"
+    - dependency-name: "npm-run-all"
+    - dependency-name: "prettier"
+    - dependency-name: "rimraf"
+    - dependency-name: "ts-jest"
+    - dependency-name: "ts-node"
+    - dependency-name: "tsconfig-paths"
+    - dependency-name: "typescript"
+    - dependency-name: "wait-on"
 
-	###Block(dependabotPackageManagers)
+  ###Block(dependabotPackageManagers)
 
-	###EndBlock(dependabotPackageManagers)
+  ###EndBlock(dependabotPackageManagers)
 )


### PR DESCRIPTION
apparently YAML doesn't allow tabs ????

```
[error] .github/dependabot.yml: SyntaxError: Plain value cannot start with a tab character (5:1)
[error]   3 | updates:
[error]   4 | 	# Golang dependencies
[error] > 5 | 	- package-ecosystem: "gomod"
[error]     | ^^^^^^^^^^^^^^^^^^^^
[error]   6 | 		directory: "/"
[error]   7 | 		schedule:
[error]   8 | 			interval: "daily"
make: *** [fmt] Error 1
ERRO[0086] failed to run: run codegen: failed to run post run command for module "github.com/getoutreach/stencil-base": exit status 2
ERRO[0112] failed to run: failed to run stencil: exit status 1
```

<!--
  !!!! README !!!! Please fill this out.

  Please follow the PR naming conventions:
  https://outreach-io.atlassian.net/wiki/spaces/EN/pages/1902444645/Conventional+Commits
-->

<!-- A short description of what your PR does and what it solves. -->

## What this PR does / why we need it

- changes tabs to spaces in dependabot.yml
<!--- Block(jiraPrefix) --->

## Jira ID

[QSS-1316]

<!--- EndBlock(jiraPrefix) --->

<!-- Notes that may be helpful for anyone reviewing this PR -->

## Notes for your reviewers

<!--- Block(custom) -->

<!--- EndBlock(custom) -->


[QSS-1316]: https://outreach-io.atlassian.net/browse/QSS-1316?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ