### PR TITLE
fix(monitoring): cleanup leftover serviceDomain reference

### DIFF
--- a/templates/monitoring/datadog.tf.tpl
+++ b/templates/monitoring/datadog.tf.tpl
@@ -338,7 +338,7 @@ resource "datadog_service_level_objective" "grpc_p99_latency" {
   tags = local.ddTags
   monitor_ids = [module.grpc_latency_high.high_traffic_id]
   groups = [
-    {{- $bentos := extensions.Call "github.com/getoutreach/stencil-discovery.Bentos" (stencil.Arg "deployment.environments") (stencil.Arg "deployment.serviceDomain")}}
+    {{- $bentos := extensions.Call "github.com/getoutreach/stencil-discovery.Bentos" (stencil.Arg "deployment.environments") (stencil.Arg "deployment.serviceDomains") }}
     {{- range $b := $bentos }}
     "kube_namespace:{{ stencil.ApplyTemplate "goPackageSafeName" }}--{{ $b.name }}",
     {{- end }}


### PR DESCRIPTION
<!--
  !!!! README !!!! Please fill this out.

  Please follow the PR naming conventions:
  https://outreach-io.atlassian.net/wiki/spaces/EN/pages/1902444645/Conventional+Commits
-->

<!-- A short description of what your PR does and what it solves. -->

## What this PR does / why we need it

This PR cleans up a leftover `serviceDomain` reference when we moved to `serviceDomains`.

<!--- Block(jiraPrefix) --->

## Jira ID

[XX-XX]

<!--- EndBlock(jiraPrefix) --->

<!-- Notes that may be helpful for anyone reviewing this PR -->

## Notes for your reviewers

<!--- Block(custom) -->

<!--- EndBlock(custom) -->
