### PR TITLE
fix(rpc): allow to pass server options

### DIFF
--- a/templates/_helpers.tpl
+++ b/templates/_helpers.tpl
@@ -23,7 +23,7 @@
   version: 2.6.6
 # Used in CI
 - name: protoc
-  version: 3.19.1
+  version: 21.5
 {{- end }}
 
 # Registers our versions w/ stencil-base

--- a/templates/_helpers.tpl
+++ b/templates/_helpers.tpl
@@ -23,7 +23,7 @@
   version: 2.6.6
 # Used in CI
 - name: protoc
-  version: 21.5
+  version: 3.19.1
 {{- end }}
 
 # Registers our versions w/ stencil-base

--- a/templates/internal/appName/rpc/rpc.go.tpl
+++ b/templates/internal/appName/rpc/rpc.go.tpl
@@ -108,7 +108,7 @@ func (s *GRPCService) Close(ctx context.Context) error {
 }
 
 // StartServer starts a RPC server with the provided implementation.
-func StartServer(ctx context.Context, service api.Service) (*grpc.Server, error) {
+func StartServer(ctx context.Context, service api.Service, opts... grpcx.ServerOption) (*grpc.Server, error) {
 	{{- $grpcServerOptionInit := stencil.GetModuleHook "internal/rpc/grpcServerOptionInit" }}
 	{{- if $grpcServerOptionInit }}
 	// gRPC server option initialization injected by modules
@@ -119,7 +119,7 @@ func StartServer(ctx context.Context, service api.Service) (*grpc.Server, error)
 	// end gRPC server option initialization injected by modules
 	{{- end }}
 
-	opts := []grpcx.ServerOption{
+	opts = append([]grpcx.ServerOption{
 		{{- $grpcServerOptions := stencil.GetModuleHook "internal/rpc/grpcServerOptions" }}
 		{{- if $grpcServerOptions }}
 		// gRPC server options injected by modules
@@ -128,7 +128,7 @@ func StartServer(ctx context.Context, service api.Service) (*grpc.Server, error)
 			{{- end }}
 		// end gRPC server options injected by modules
 		{{- end }}
-	}
+	}, opts...)
 
 	///Block(grpcServerOptions)
 {{ file.Block "grpcServerOptions" }}

--- a/templates/internal/appName/rpc/rpc.go.tpl
+++ b/templates/internal/appName/rpc/rpc.go.tpl
@@ -80,7 +80,7 @@ func (s *GRPCService) Run(ctx context.Context) error {
 	{{- end }}
 		///EndBlock(server)
 
-		srv, err := StartServer(ctx, server, ops...)
+		srv, err := StartServer(ctx, server, opts...)
 		if err != nil {
 				log.Error(ctx, "failed to start server", events.NewErrorInfo(err))
 				return err

--- a/templates/internal/appName/rpc/rpc.go.tpl
+++ b/templates/internal/appName/rpc/rpc.go.tpl
@@ -65,7 +65,7 @@ func (s *GRPCService) Run(ctx context.Context) error {
 		}
 		defer lis.Close()
 
-		var ops []grpcx.ServerOption
+		var opts []grpcx.ServerOption
 		// Initialize your server instance here.
 		//
 		///Block(server)

--- a/templates/internal/appName/rpc/rpc.go.tpl
+++ b/templates/internal/appName/rpc/rpc.go.tpl
@@ -65,6 +65,7 @@ func (s *GRPCService) Run(ctx context.Context) error {
 		}
 		defer lis.Close()
 
+		var ops []grpcx.ServerOption
 		// Initialize your server instance here.
 		//
 		///Block(server)
@@ -73,13 +74,13 @@ func (s *GRPCService) Run(ctx context.Context) error {
 	{{- else }}
 		server, err := NewServer(ctx, s.cfg)
 		if err != nil {
-				log.Error(ctx, "failed to start server", events.NewErrorInfo(err))
+				log.Error(ctx, "failed to create new server", events.NewErrorInfo(err))
 				return err
 		}
 	{{- end }}
 		///EndBlock(server)
 
-		srv, err := StartServer(ctx, server)
+		srv, err := StartServer(ctx, server, ops...)
 		if err != nil {
 				log.Error(ctx, "failed to start server", events.NewErrorInfo(err))
 				return err


### PR DESCRIPTION
<!--
  !!!! README !!!! Please fill this out.

  Please follow the PR naming conventions:
  https://outreach-io.atlassian.net/wiki/spaces/EN/pages/1902444645/Conventional+Commits
-->

<!-- A short description of what your PR does and what it solves. -->

## What this PR does / why we need it

This PR adds support for passing gRPC options to `StartServer`

<!--- Block(jiraPrefix) --->

## Jira ID

[DT-2606]

<!--- EndBlock(jiraPrefix) --->

<!-- Notes that may be helpful for anyone reviewing this PR -->

## Notes for your reviewers

<!--- Block(custom) -->

<!--- EndBlock(custom) -->


[DT-2606]: https://outreach-io.atlassian.net/browse/DT-2606?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ