### PR TITLE
fix: do not render devenv.yaml for non-services

### DIFF
--- a/templates/devenv.yaml.tpl
+++ b/templates/devenv.yaml.tpl
@@ -1,3 +1,4 @@
+{{- $_ := stencil.ApplyTemplate "skipIfNotService" -}}
 service: {{ stencil.Arg "service" }}
 dependencies:
 {{- if gt (len (stencil.GetModuleHook "devenv.dependencies.optional")) 0 }}


### PR DESCRIPTION
<!--
  !!!! README !!!! Please fill this out.

  Please follow the PR naming conventions:
  https://outreach-io.atlassian.net/wiki/spaces/EN/pages/1902444645/Conventional+Commits
-->

<!-- A short description of what your PR does and what it solves. -->

## What this PR does / why we need it

devenv.yaml should not render for non-services (libraries and CLIs)

<!--- Block(jiraPrefix) --->

## Jira ID

https://outreach-io.atlassian.net/browse/DT-2176

<!--- EndBlock(jiraPrefix) --->

<!-- Notes that may be helpful for anyone reviewing this PR -->

## Notes for your reviewers

<!--- Block(custom) -->

<!--- EndBlock(custom) -->
