### PR TITLE
fix: upgrade protoc to 21.5, aka 3.21.5

### DIFF
--- a/templates/_helpers.tpl
+++ b/templates/_helpers.tpl
@@ -23,7 +23,7 @@
   version: 2.6.6
 # Used in CI
 - name: protoc
-  version: 3.19.1
+  version: 21.5
 {{- end }}
 
 # Registers our versions w/ stencil-base


### PR DESCRIPTION
<!--
  !!!! README !!!! Please fill this out.

  Please follow the PR naming conventions:
  https://outreach-io.atlassian.net/wiki/spaces/EN/pages/1902444645/Conventional+Commits
-->

<!-- A short description of what your PR does and what it solves. -->

## What this PR does / why we need it
We have recently moved to protoc 3.21.5 (released under tag = 21.5). However, stencil-golang keeps reverting it back. Putting a patch here to ensure it sticks.

<!--- Block(jiraPrefix) --->

## Jira ID

[CDT-00]

<!--- EndBlock(jiraPrefix) --->

<!-- Notes that may be helpful for anyone reviewing this PR -->

## Notes for your reviewers

<!--- Block(custom) -->

<!--- EndBlock(custom) -->
