### PR TITLE
fix(dockerfile): use go mod download over make dep

### DIFF
--- a/templates/.snapshots/TestRenderDeploymentDockerfile-deployments-appname-Dockerfile.tpl-deployments-testing-Dockerfile.snapshot
+++ b/templates/.snapshots/TestRenderDeploymentDockerfile-deployments-appname-Dockerfile.tpl-deployments-testing-Dockerfile.snapshot
@@ -14,7 +14,7 @@ COPY . .
 ###EndBlock(beforeBuild)
 
 # Cache dependencies across builds
-RUN --mount=type=ssh --mount=type=cache,target=/go/pkg make dep
+RUN --mount=type=ssh --mount=type=cache,target=/go/pkg go mod download
 
 # Build our application, caching the go build cache, but also using
 # the dependency cache from earlier.

--- a/templates/deployments/appname/Dockerfile.tpl
+++ b/templates/deployments/appname/Dockerfile.tpl
@@ -17,7 +17,7 @@ COPY . .
 ###EndBlock(beforeBuild)
 
 # Cache dependencies across builds
-RUN --mount=type=ssh --mount=type=cache,target=/go/pkg make dep
+RUN --mount=type=ssh --mount=type=cache,target=/go/pkg go mod download
 
 # Build our application, caching the go build cache, but also using
 # the dependency cache from earlier.

--- a/templates/main_test.go
+++ b/templates/main_test.go
@@ -43,7 +43,7 @@ func TestRenderDeploymentDockerfile(t *testing.T) {
 			"alpine": "3.1",
 		},
 	})
-	st.Run(false)
+	st.Run(true)
 }
 
 func TestRenderDependabot(t *testing.T) {


### PR DESCRIPTION
<!--
  !!!! README !!!! Please fill this out.

  Please follow the PR naming conventions:
  https://outreach-io.atlassian.net/wiki/spaces/EN/pages/1902444645/Conventional+Commits
-->

<!-- A short description of what your PR does and what it solves. -->

## What this PR does / why we need it

Since we moved to `mage` in devbase, we now have an issue where `make dep` can fail with `mage` not being installed. Instead of hacking in mage, for now we switch to `go mod download`. We need to redesign this dockerfile to unify the tooling between CI, local, and docker images to go back to calling `make` in the dockerfile

<!--- Block(jiraPrefix) --->

## Jira ID

[DT-2825]

<!--- EndBlock(jiraPrefix) --->

<!-- Notes that may be helpful for anyone reviewing this PR -->

## Notes for your reviewers

<!--- Block(custom) -->

<!--- EndBlock(custom) -->


[DT-2825]: https://outreach-io.atlassian.net/browse/DT-2825?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ