### PR TITLE
feat: get rid of Ruby 2.6 references

### DIFF
--- a/templates/_helpers.tpl
+++ b/templates/_helpers.tpl
@@ -20,7 +20,7 @@
   version: 0.13.5
 # Just in case bundler/etc needs to be used in the root.
 - name: ruby
-  version: 2.6.6
+  version: 2.7.5
 # Used in CI
 - name: protoc
   version: 21.5

--- a/templates/api/clients/ruby/.tool-versions.tpl
+++ b/templates/api/clients/ruby/.tool-versions.tpl
@@ -1,6 +1,6 @@
 # Contains asdf versions for a ruby gRPC client.
 {{- $_ := stencil.ApplyTemplate "skipGrpcClient" "ruby" }}
-ruby 2.6.6
+ruby 2.7.5
 ###Block(rubyToolVersions)
 {{- if file.Block "rubyToolVersions" }}
 {{ file.Block "rubyToolVersions" | stencil.Render "ruby" }}

--- a/templates/api/clients/ruby/client.gemspec.tpl
+++ b/templates/api/clients/ruby/client.gemspec.tpl
@@ -11,7 +11,7 @@ Gem::Specification.new do |spec|
   spec.metadata["source_code_uri"] = spec.homepage
   spec.metadata["github_repo"] = "ssh://github.com/getoutreach/{{ .Config.Name }}"
 
-  spec.required_ruby_version = Gem::Requirement.new(">= 2.6.6")
+  spec.required_ruby_version = Gem::Requirement.new(">= 2.7.5")
   spec.files         = Dir.chdir(File.expand_path('..', __FILE__)) do
     `git ls-files -z`.split("\x0").reject { |f| f.match(%r{^(test|spec|features)/}) }
   end


### PR DESCRIPTION
context: https://outreach-hq.slack.com/archives/CN9MU7GLW/p1663335947482609?thread_ts=1663330514.908369&cid=CN9MU7GLW