### PR TITLE
fix(devspace): pass box URL

### DIFF
--- a/templates/devspace.yaml.tpl
+++ b/templates/devspace.yaml.tpl
@@ -85,7 +85,7 @@ vars:
     command: make version
   - name: BOX_REPOSITORY_URL
     source: command
-    command: yq -r '.storageURL' "$HOME/.outreach/.config/box/config.yml"
+    command: yq -r '.storageURL' "$HOME/.outreach/.config/box/box.yaml"
 
   - name: DLV_PORT
     value: 42097

--- a/templates/devspace.yaml.tpl
+++ b/templates/devspace.yaml.tpl
@@ -226,7 +226,7 @@ dev:
           value:
             name: DEV_CONTAINER_EXECUTABLE
             value: ${DEV_CONTAINER_EXECUTABLE}
-        - op:
+        - op: add
           path: spec.containers[0].env
           value:
             name: BOX_REPOSITORY_URL

--- a/templates/devspace.yaml.tpl
+++ b/templates/devspace.yaml.tpl
@@ -82,7 +82,10 @@ vars:
     command: grep -E "registry.npmjs.org(.+)_authToken=(.+)" $HOME/.npmrc | sed 's/.*=//g'
   - name: APP_VERSION
     source: command
-    command: git describe --match 'v[0-9]*' --tags --always HEAD
+    command: make version
+  - name: BOX_REPOSITORY_URL
+    source: command
+    command: yq -r '.storageURL' "$HOME/.outreach/.config/box/config.yml"
 
   - name: DLV_PORT
     value: 42097
@@ -223,6 +226,11 @@ dev:
           value:
             name: DEV_CONTAINER_EXECUTABLE
             value: ${DEV_CONTAINER_EXECUTABLE}
+        - op:
+          path: spec.containers[0].env
+          value:
+            name: BOX_REPOSITORY_URL
+            value: ${BOX_REPOSITORY_URL}
 
         # Package caching
         - op: add


### PR DESCRIPTION
<!--
  !!!! README !!!! Please fill this out.

  Please follow the PR naming conventions:
  https://outreach-io.atlassian.net/wiki/spaces/EN/pages/1902444645/Conventional+Commits
-->

<!-- A short description of what your PR does and what it solves. -->

## What this PR does / why we need it

This PR exposes `BOX_REPOSITORY_URL` to the devspace container, which is used by `box.sh` for downloading box. This helps implement https://github.com/getoutreach/devbase/pull/309

<!--- Block(jiraPrefix) --->

## Jira ID

[DT-2843]

<!--- EndBlock(jiraPrefix) --->

<!-- Notes that may be helpful for anyone reviewing this PR -->

## Notes for your reviewers

<!--- Block(custom) -->

<!--- EndBlock(custom) -->


[DT-2843]: https://outreach-io.atlassian.net/browse/DT-2843?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ