### PR TITLE
fix(grpc/client): remove duplicate import, pass clientOpts to grpcx

### DIFF
--- a/templates/api/rpc/client.go.tpl
+++ b/templates/api/rpc/client.go.tpl
@@ -14,7 +14,6 @@ package {{ stencil.ApplyTemplate "goPackageSafeName" }} //nolint:revive // Why: 
 import (
 	"context"
 
-	"github.com/getoutreach/mint/pkg/authn"
 	"github.com/getoutreach/services/pkg/grpcx"
 	"github.com/getoutreach/{{ .Config.Name }}/api"
 
@@ -56,7 +55,7 @@ func New(ctx context.Context) (api.Service, error) {
 		{{- end }}
 	}
 
-	conn, err := grpcx.NewClientConn(ctx, "{{ .Config.Name }}", useAuthn, useDiscovery)
+	conn, err := grpcx.NewClientConn(ctx, "{{ .Config.Name }}", clientOpts...)
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
<!--
  !!!! README !!!! Please fill this out.

  Please follow the PR naming conventions:
  https://outreach-io.atlassian.net/wiki/spaces/EN/pages/1902444645/Conventional+Commits
-->

<!-- A short description of what your PR does and what it solves. -->

## What this PR does / why we need it

This PR fixes `client.go` to properly generate the first time

<!-- <<Stencil::Block(jiraPrefix)>> -->

## Jira ID

[DT-2808]

<!-- <</Stencil::Block>> -->

<!-- Notes that may be helpful for anyone reviewing this PR -->

## Notes for your reviewers

<!-- <<Stencil::Block(custom)>> -->

<!-- <</Stencil::Block>> -->


[DT-2808]: https://outreach-io.atlassian.net/browse/DT-2808?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ