### PR TITLE
fix: include .git directory in devbase sync

### DIFF
--- a/templates/devspace.yaml.tpl
+++ b/templates/devspace.yaml.tpl
@@ -151,7 +151,6 @@ dev:
       containerPath: ${DEV_CONTAINER_WORKDIR}
       waitInitialSync: true
       excludePaths:
-        - .git
         - bin
         - ./vendor
         - node_modules


### PR DESCRIPTION
<!--
  !!!! README !!!! Please fill this out.

  Please follow the PR naming conventions:
  https://outreach-io.atlassian.net/wiki/spaces/EN/pages/1902444645/Conventional+Commits
-->

<!-- A short description of what your PR does and what it solves. -->

## What this PR does / why we need it

When running tests and linters inside a devenv container, they complain about the project not being a git repository. This includes the necessary git directory. This shouldn't increase the image size too much and will allow all commands to run successfully inside the devspace pod.

<!-- <<Stencil::Block(jiraPrefix)>> -->

## Jira ID

[XX-XX]

<!-- <</Stencil::Block>> -->

<!-- Notes that may be helpful for anyone reviewing this PR -->

## Notes for your reviewers

<!-- <<Stencil::Block(custom)>> -->

<!-- <</Stencil::Block>> -->
