### PR TITLE
feat: generate/merge go.mod

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -7,14 +7,15 @@ orbs:
 # Extra contexts to expose to all jobs below
 contexts: &contexts
   - aws-credentials
+  - ghaccesstoken
+  - docker-registry
   - npm-credentials
   - prismacloud-credentials
   - opslevel-credentials
   - vault-dev
   - confluence
   ## <<Stencil::Block(extraContexts)>>
-  - docker-registry
-  - ghaccesstoken
+
   ## <</Stencil::Block>>
 
 # Branches used for releasing code, pre-release or not

--- a/.editorconfig
+++ b/.editorconfig
@@ -14,5 +14,6 @@ indent_size  = 2
 
 ## <<Stencil::Block(editorconfig)>>
 [*.tpl]
-indent_style = tab
+indent_style = space
+indent_size =  2
 ## <</Stencil::Block>>

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -1,0 +1,24 @@
+before:
+  hooks:
+    - make dep
+builds:
+  - main: ./plugin
+    id: &name stencil-golang
+    binary: *name
+    goos:
+      - linux
+      - darwin
+    goarch:
+      - amd64
+      - arm64
+    ldflags:
+      - '-w -s -X "github.com/getoutreach/gobox/pkg/app.Version=v{{ .Version }}"'
+      - '-X "main.HoneycombTracingKey={{ .Env.HONEYCOMB_APIKEY }}"'
+    env:
+      - CGO_ENABLED=0
+archives: []
+checksum:
+  name_template: "checksums.txt"
+release:
+  # We handle releasing via semantic-release
+  disable: true

--- a/.releaserc.yaml
+++ b/.releaserc.yaml
@@ -10,10 +10,27 @@ plugins:
           release: patch
         - type: perf
           release: patch
+  # Block major version upgrades due to us not supporting them that well. This can
+  # be disabled by setting releaseOptions.allowMajorVersions, but be warned this
+  # is not well supported for services.
+  - - "@semantic-release/exec"
+    # We use generateNotesCmd instead of verifyConditionsCmd because it has access
+    # to last/nextRelease due to when the step runs.
+    - generateNotesCmd: |-
+        ./scripts/shell-wrapper.sh major-release-checker.js ${lastRelease.version} ${nextRelease.version}
+  # Build the binaries
+  - - "@semantic-release/exec"
+    # We use generateNotesCmd instead of a different step because it has access
+    # to last/nextRelease due to when the step runs.
+    - generateNotesCmd: "make release APP_VERSION=${nextRelease.version}"
 
   # This creates fancy release notes in our Github release
   - "@semantic-release/release-notes-generator"
-  - "@semantic-release/github"
+  # Create the Github Release
+  - - "@semantic-release/github"
+    - assets:
+        - "dist/*.tar.gz"
+        - "dist/checksums.txt"
 
   ## <<Stencil::Block(customReleasePlugins)>>
 

--- a/bootstrap.lock
+++ b/bootstrap.lock
@@ -1,4 +1,4 @@
 versions:
   # HACK(jaredallard): Remove when stencil-base is cleaned up and bootstrap
   # is dead.
-  devbase: v2.4.0-rc.1
+  devbase: v2.4.0-rc.5

--- a/go.sum
+++ b/go.sum
@@ -88,6 +88,7 @@ github.com/beevik/etree v1.1.0/go.mod h1:r8Aw8JqVegEf0w2fDnATrX9VpkMcyFeM0FhwO62
 github.com/beorn7/perks v0.0.0-20180321164747-3a771d992973/go.mod h1:Dwedo/Wpr24TaqPxmxbtue+5NUziq4I4S80YR8gNf3Q=
 github.com/beorn7/perks v1.0.0/go.mod h1:KWe93zE9D1o94FZ5RNwFwVgaQK1VOXiVxmqh+CedLV8=
 github.com/beorn7/perks v1.0.1/go.mod h1:G2ZrVWU2WbWT9wwq4/hrbKbnv/1ERSJQ0ibhJ6rlkpw=
+github.com/blang/semver/v4 v4.0.0 h1:1PFHFE6yCCTv8C1TeyNNarDzntLi7wMI5i/pzqYIsAM=
 github.com/blang/semver/v4 v4.0.0/go.mod h1:IbckMUScFkM3pff0VJDNKRiT6TG/YpiHIM2yvyW5YoQ=
 github.com/bradleyjkemp/cupaloy v2.3.0+incompatible h1:UafIjBvWQmS9i/xRg+CamMrnLTKNzo+bdmT/oH34c2Y=
 github.com/bradleyjkemp/cupaloy v2.3.0+incompatible/go.mod h1:Au1Xw1sgaJ5iSFktEhYsS0dbQiS1B0/XMXl+42y9Ilk=
@@ -163,8 +164,8 @@ github.com/flynn/go-shlex v0.0.0-20150515145356-3f9db97f8568/go.mod h1:xEzjJPgXI
 github.com/fsnotify/fsnotify v1.4.7/go.mod h1:jwhsz4b93w/PPRr/qN1Yymfu8t87LnFCMoQvtojpjFo=
 github.com/getoutreach/gobox v1.53.0 h1:X8Jwxzhyk81X4vTj3pnEEqXIYymvVulz115cqL7XhtQ=
 github.com/getoutreach/gobox v1.53.0/go.mod h1:/yxedTR3b6TIcxc/QZ58q8C5Lhmp4nu0zZL4TVzykuw=
-github.com/getoutreach/stencil v1.27.0 h1:wnXtxYswIPndTBo6kK2pbMPPXvBmOw28e/ZQun6KQtY=
-github.com/getoutreach/stencil v1.27.0/go.mod h1:JSiu0kKPC2tuEkizn7j4Z62e0+8J2040vsa6ytbi+Po=
+github.com/getoutreach/stencil v1.28.0-rc.2 h1:zALhcs5/3z2noPJ5Lll6BYV9g5pvYttcTZUVrMNXYE4=
+github.com/getoutreach/stencil v1.28.0-rc.2/go.mod h1:HWT52m7XEK587xSUVp4j/Ki2Gc+fKKRdIsOwrM/KsAk=
 github.com/ghodss/yaml v1.0.0/go.mod h1:4dBDuWmgqj2HViK6kFavaiC9ZROes6MMH2rRYeMEF04=
 github.com/gin-contrib/sse v0.1.0/go.mod h1:RHrZQHXnP2xjPF+u1gW/2HnVO7nvIa9PG3Gm+fLHvGI=
 github.com/gin-gonic/gin v1.7.7/go.mod h1:axIBovoeJpVj8S3BwE0uPMTeReE4+AfFtqpqaZ1qq1U=
@@ -323,8 +324,9 @@ github.com/hashicorp/go-plugin v1.4.5/go.mod h1:viDMjcLJuDui6pXb8U4HVfb8AamCWhHG
 github.com/hashicorp/golang-lru v0.5.0/go.mod h1:/m3WP610KZHVQ1SGc6re/UDhFvYD7pJ4Ao+sR/qLZy8=
 github.com/hashicorp/golang-lru v0.5.1/go.mod h1:/m3WP610KZHVQ1SGc6re/UDhFvYD7pJ4Ao+sR/qLZy8=
 github.com/hashicorp/hcl v1.0.0/go.mod h1:E5yfLk+7swimpb2L/Alb/PJmXilQ/rhwaUYs4T20WEQ=
-github.com/hashicorp/yamux v0.0.0-20180604194846-3520598351bb h1:b5rjCoWHc7eqmAS4/qyk21ZsHyb6Mxv/jykxvNTkU4M=
 github.com/hashicorp/yamux v0.0.0-20180604194846-3520598351bb/go.mod h1:+NfK9FKeTrX5uv1uIXGdwYDTeHna2qgaIlx54MXqjAM=
+github.com/hashicorp/yamux v0.0.0-20181012175058-2f1d1f20f75d h1:kJCB4vdITiW1eC1vq2e6IsrXKrZit1bv/TDYFGMp4BQ=
+github.com/hashicorp/yamux v0.0.0-20181012175058-2f1d1f20f75d/go.mod h1:+NfK9FKeTrX5uv1uIXGdwYDTeHna2qgaIlx54MXqjAM=
 github.com/hinshun/vt10x v0.0.0-20180616224451-1954e6464174/go.mod h1:DqJ97dSdRW1W22yXSB90986pcOyQ7r45iio1KN2ez1A=
 github.com/hinshun/vt10x v0.0.0-20220119200601-820417d04eec h1:qv2VnGeEQHchGaZ/u7lxST/RaJw+cv273q79D81Xbog=
 github.com/hinshun/vt10x v0.0.0-20220119200601-820417d04eec/go.mod h1:Q48J4R4DvxnHolD5P8pOtXigYlRuPLGl6moFx3ulM68=
@@ -428,6 +430,8 @@ github.com/lib/pq v1.2.0/go.mod h1:5WUZQaWbwv1U+lTReE5YruASi9Al49XbQIvNi/34Woo=
 github.com/lib/pq v1.3.0/go.mod h1:5WUZQaWbwv1U+lTReE5YruASi9Al49XbQIvNi/34Woo=
 github.com/lucasb-eyer/go-colorful v1.2.0/go.mod h1:R4dSotOR9KMtayYi1e77YzuveK+i7ruzyGqttikkLy0=
 github.com/luna-duclos/instrumentedsql v1.1.3/go.mod h1:9J1njvFds+zN7y85EDhN9XNQLANWwZt2ULeIC8yMNYs=
+github.com/magefile/mage v1.14.0 h1:6QDX3g6z1YvJ4olPhT1wksUcSa/V0a1B+pJb73fBjyo=
+github.com/magefile/mage v1.14.0/go.mod h1:z5UZb/iS3GoOSn0JgWuiw7dxlurVYTu+/jHXqQg881A=
 github.com/magiconair/properties v1.8.0/go.mod h1:PppfXfuXeibc/6YijjN8zIbojt8czPbwD3XqdrwzmxQ=
 github.com/manifoldco/promptui v0.9.0/go.mod h1:ka04sppxSGFAtxX0qhlYQjISsg9mR4GWtQEhdbn6Pgg=
 github.com/markbates/errx v1.1.0/go.mod h1:PLa46Oex9KNbVDZhKel8v1OT7hD5JZ2eI7AHhA0wswc=
@@ -563,8 +567,9 @@ github.com/sourcegraph/syntaxhighlight v0.0.0-20170531221838-bd320f5d308e/go.mod
 github.com/spaolacci/murmur3 v0.0.0-20180118202830-f09979ecbc72/go.mod h1:JwIasOWyU6f++ZhiEuf87xNszmSA2myDM2Kzu9HwQUA=
 github.com/spf13/afero v1.1.2/go.mod h1:j4pytiNVoe2o6bmDsKpLACNPDBIoEAkihy7loJ1B0CQ=
 github.com/spf13/cast v1.3.0/go.mod h1:Qx5cxh0v+4UWYiBimWS+eyWzqEqokIECu5etghLkUJE=
-github.com/spf13/cast v1.3.1 h1:nFm6S0SMdyzrzcmThSipiEubIDy8WEXKNZ0UOgiRpng=
 github.com/spf13/cast v1.3.1/go.mod h1:Qx5cxh0v+4UWYiBimWS+eyWzqEqokIECu5etghLkUJE=
+github.com/spf13/cast v1.4.1 h1:s0hze+J0196ZfEMTs80N7UlFt0BDuQ7Q+JDnHiMWKdA=
+github.com/spf13/cast v1.4.1/go.mod h1:Qx5cxh0v+4UWYiBimWS+eyWzqEqokIECu5etghLkUJE=
 github.com/spf13/cobra v0.0.6/go.mod h1:/6GTrnGXV9HjY+aR4k0oJ5tcvakLuG6EuKReYlHNrgE=
 github.com/spf13/cobra v1.0.0/go.mod h1:/6GTrnGXV9HjY+aR4k0oJ5tcvakLuG6EuKReYlHNrgE=
 github.com/spf13/jwalterweatherman v1.0.0/go.mod h1:cQK4TGJAtQXfYWX+Ddv3mKDzgVb68N+wFjFa4jdeBTo=
@@ -702,6 +707,7 @@ golang.org/x/mod v0.1.1-0.20191107180719-034126e5016b/go.mod h1:QqPTAvyqsEbceGzB
 golang.org/x/mod v0.2.0/go.mod h1:s0Qsj1ACt9ePp/hMypM3fl4fZqREWJwdYDEqhRiZZUA=
 golang.org/x/mod v0.3.0/go.mod h1:s0Qsj1ACt9ePp/hMypM3fl4fZqREWJwdYDEqhRiZZUA=
 golang.org/x/mod v0.4.2/go.mod h1:s0Qsj1ACt9ePp/hMypM3fl4fZqREWJwdYDEqhRiZZUA=
+golang.org/x/mod v0.6.0-dev.0.20220106191415-9b9b3d81d5e3 h1:kQgndtyPBW/JIYERgdxfwMYh3AVStj88WQTlNDi2a+o=
 golang.org/x/mod v0.6.0-dev.0.20220106191415-9b9b3d81d5e3/go.mod h1:3p9vT2HGsQu2K1YbXdKPJLVgG5VJdoTa1poYQBtP1AY=
 golang.org/x/net v0.0.0-20180530234432-1e491301e022/go.mod h1:mL1N/T3taQHkDXs73rZJwtUhF3w3ftmwwsq0BUmARs4=
 golang.org/x/net v0.0.0-20180724234803-3673e40ba225/go.mod h1:mL1N/T3taQHkDXs73rZJwtUhF3w3ftmwwsq0BUmARs4=
@@ -908,6 +914,7 @@ golang.org/x/xerrors v0.0.0-20190513163551-3ee3066db522/go.mod h1:I/5z698sn9Ka8T
 golang.org/x/xerrors v0.0.0-20190717185122-a985d3407aa7/go.mod h1:I/5z698sn9Ka8TeJc9MKroUUfqBBauWjQqLJ2OPfmY0=
 golang.org/x/xerrors v0.0.0-20191011141410-1b5146add898/go.mod h1:I/5z698sn9Ka8TeJc9MKroUUfqBBauWjQqLJ2OPfmY0=
 golang.org/x/xerrors v0.0.0-20191204190536-9bdfabe68543/go.mod h1:I/5z698sn9Ka8TeJc9MKroUUfqBBauWjQqLJ2OPfmY0=
+golang.org/x/xerrors v0.0.0-20200804184101-5ec99f83aff1 h1:go1bK/D/BFZV2I8cIQd1NKEZ+0owSTG1fDTci4IqFcE=
 golang.org/x/xerrors v0.0.0-20200804184101-5ec99f83aff1/go.mod h1:I/5z698sn9Ka8TeJc9MKroUUfqBBauWjQqLJ2OPfmY0=
 google.golang.org/api v0.4.0/go.mod h1:8k5glujaEP+g9n7WNsDg8QP6cUVNI86fCNMcbazEtwE=
 google.golang.org/api v0.7.0/go.mod h1:WtwebWUNSVBH/HAw79HIFXZNqEvBhG+Ra+ax0hx3E3M=
@@ -965,8 +972,8 @@ google.golang.org/genproto v0.0.0-20200729003335-053ba62fc06f/go.mod h1:FWY/as6D
 google.golang.org/genproto v0.0.0-20200804131852-c06518451d9c/go.mod h1:FWY/as6DDZQgahTzZj3fqbO1CbirC29ZNUFHwi0/+no=
 google.golang.org/genproto v0.0.0-20200825200019-8632dd797987/go.mod h1:FWY/as6DDZQgahTzZj3fqbO1CbirC29ZNUFHwi0/+no=
 google.golang.org/genproto v0.0.0-20211118181313-81c1377c94b1/go.mod h1:5CzLGKJ67TSI2B9POpiiyGha0AjJvZIUgRMt1dSmuhc=
-google.golang.org/genproto v0.0.0-20220107163113-42d7afdf6368 h1:Et6SkiuvnBn+SgrSYXs/BrUpGB4mbdwt4R3vaPIlicA=
-google.golang.org/genproto v0.0.0-20220107163113-42d7afdf6368/go.mod h1:5CzLGKJ67TSI2B9POpiiyGha0AjJvZIUgRMt1dSmuhc=
+google.golang.org/genproto v0.0.0-20220111164026-67b88f271998 h1:g/x+MYjJYDEP3OBCYYmwIbt4x6k3gryb+ohyOR7PXfI=
+google.golang.org/genproto v0.0.0-20220111164026-67b88f271998/go.mod h1:5CzLGKJ67TSI2B9POpiiyGha0AjJvZIUgRMt1dSmuhc=
 google.golang.org/grpc v1.8.0/go.mod h1:yo6s7OP7yaDglbqo1J04qKzAhqBH6lvTonzMVmEdcZw=
 google.golang.org/grpc v1.19.0/go.mod h1:mqu4LbDTu4XGKhr4mRzUsmM4RtVoemTSY81AxZiDr8c=
 google.golang.org/grpc v1.20.1/go.mod h1:10oTOabMzJvdu6/UiuZezV6QK5dSlG84ov/aaiqXj38=

--- a/internal/plugin/merge.go
+++ b/internal/plugin/merge.go
@@ -44,7 +44,6 @@ func MergeGoMod(t *apiv1.TemplateFunctionExec) (string, error) { //nolint:funlen
 
 	originalModHM := make(map[string]semver.Version)
 	for _, mod := range origMod.Require {
-		//nolint:govet // Why: We're OK shadowing err
 		v, err := semver.ParseTolerant(mod.Mod.Version)
 		if err != nil {
 			continue
@@ -61,7 +60,6 @@ func MergeGoMod(t *apiv1.TemplateFunctionExec) (string, error) { //nolint:funlen
 	// Change the left hand module versions if the right hand versions
 	// are greater than the left hand ones.
 	for _, req := range templateMod.Require {
-		//nolint:govet /// Why: We're OK shadowing err
 		v, err := semver.ParseTolerant(req.Mod.Version)
 		if err != nil {
 			continue

--- a/internal/plugin/merge.go
+++ b/internal/plugin/merge.go
@@ -1,0 +1,112 @@
+package plugin
+
+import (
+	"fmt"
+	"reflect"
+
+	"github.com/blang/semver/v4"
+	"github.com/getoutreach/stencil/pkg/extensions/apiv1"
+	"github.com/pkg/errors"
+	"golang.org/x/mod/modfile"
+)
+
+// MergeGoMod merges two go.mod files together
+func MergeGoMod(t *apiv1.TemplateFunctionExec) (string, error) { //nolint:funlen // Why: We're OK with this
+	fileNameLeftInf := t.Arguments[0]
+	modFileLeftInf := t.Arguments[1]
+	fileNameRightInf := t.Arguments[2]
+	modFileRightInf := t.Arguments[3]
+
+	fileNameLeft, ok := fileNameLeftInf.(string)
+	if !ok {
+		return "", fmt.Errorf("expected go mod file to be of type string, got %s", reflect.TypeOf(fileNameLeftInf).String())
+	}
+
+	modFileLeft, ok := modFileLeftInf.(string)
+	if !ok {
+		return "", fmt.Errorf("expected go mod file to be of type string, got %s", reflect.TypeOf(modFileLeftInf).String())
+	}
+
+	fileNameRight, ok := fileNameRightInf.(string)
+	if !ok {
+		return "", fmt.Errorf("expected go mod file to be of type string, got %s", reflect.TypeOf(fileNameRightInf).String())
+	}
+
+	modFileRight, ok := modFileRightInf.(string)
+	if !ok {
+		return "", fmt.Errorf("expected go mod file to be of type string, got %s", reflect.TypeOf(modFileRightInf).String())
+	}
+
+	origMod, err := modfile.Parse(fileNameLeft, []byte(modFileLeft), nil)
+	if err != nil {
+		return "", errors.Wrap(err, "failed to parse left go.mod")
+	}
+
+	originalModHM := make(map[string]semver.Version)
+	for _, mod := range origMod.Require {
+		//nolint:govet // Why: We're OK shadowing err
+		v, err := semver.ParseTolerant(mod.Mod.Version)
+		if err != nil {
+			continue
+		}
+
+		originalModHM[mod.Mod.Path] = v
+	}
+
+	templateMod, err := modfile.Parse(fileNameRight, []byte(modFileRight), nil)
+	if err != nil {
+		return "", errors.Wrap(err, "failed to parse right go.mod")
+	}
+
+	// Change the left hand module versions if the right hand versions
+	// are greater than the left hand ones.
+	for _, req := range templateMod.Require {
+		//nolint:govet /// Why: We're OK shadowing err
+		v, err := semver.ParseTolerant(req.Mod.Version)
+		if err != nil {
+			continue
+		}
+
+		// If it already exists, skip it if it's newer or equal to the one we want
+		if origVer, ok := originalModHM[req.Mod.Path]; ok && origVer.GTE(v) {
+			continue
+		}
+
+		if err := origMod.AddRequire(req.Mod.Path, req.Mod.Version); err != nil {
+			return "", errors.Wrapf(err, "failed to add/update dependency '%s'", req.Mod.Path)
+		}
+	}
+
+	// Carry over replacements from the right hand go.mod
+	for _, repl := range templateMod.Replace {
+		// This isn't great performance, but I suspect nobody will have a large
+		// enough amount of replaces that this will ever matter. If it does,
+		// I'm sorry :(
+		alreadyFound := false
+		for _, origRepl := range origMod.Replace {
+			// Check if we have a replace that matches
+			if origRepl.New.Path == repl.New.Path &&
+				origRepl.Old.Path == repl.Old.Path {
+				alreadyFound = true
+				break
+			}
+		}
+		if alreadyFound {
+			break
+		}
+
+		if err := origMod.AddReplace(repl.Old.Path, repl.Old.Version, repl.New.Path, repl.New.Version); err != nil {
+			return "", errors.Wrapf(err, "failed to add replace: %v", repl)
+		}
+	}
+
+	if err := origMod.AddGoStmt(templateMod.Go.Version); err != nil {
+		return "", errors.Wrap(err, "failed to set go version")
+	}
+
+	newBytes, err := origMod.Format()
+	if err != nil {
+		return "", errors.Wrap(err, "failed to save generated go.mod")
+	}
+	return string(newBytes), nil
+}

--- a/internal/plugin/plugin.go
+++ b/internal/plugin/plugin.go
@@ -1,0 +1,68 @@
+package plugin
+
+import (
+	"context"
+	"fmt"
+	"reflect"
+
+	"github.com/getoutreach/stencil/pkg/extensions/apiv1"
+	"golang.org/x/mod/modfile"
+)
+
+// _ ensures that StencilGolangPlugin fits the apiv1.Implementation interface.
+var _ apiv1.Implementation = &StencilGolangPlugin{}
+
+// StencilGolangPlugin is a type that implements the apiv1.Implementation interface to
+// serve as a stencil plugin.
+type StencilGolangPlugin struct{}
+
+// NewStencilGolangPlugin creates and initializes the stencil-golang plugin.
+func NewStencilGolangPlugin(ctx context.Context) (*StencilGolangPlugin, error) {
+	return &StencilGolangPlugin{}, nil
+}
+
+// GetConfig returns the configuration for the StencilGolangPlugin.
+func (*StencilGolangPlugin) GetConfig() (*apiv1.Config, error) {
+	return &apiv1.Config{}, nil
+}
+
+// ExecuteTemplateFunction serves as a router for template functions that the stencil-golang
+// plugin exports.
+func (*StencilGolangPlugin) ExecuteTemplateFunction(t *apiv1.TemplateFunctionExec) (interface{}, error) {
+	switch t.Name {
+	case "ParseGoMod":
+		fileNameInf := t.Arguments[0]
+		modFileInf := t.Arguments[1]
+
+		fileName, ok := fileNameInf.(string)
+		if !ok {
+			return nil, fmt.Errorf("expected go mod file to be of type string, got %s", reflect.TypeOf(fileNameInf).String())
+		}
+
+		modFile, ok := modFileInf.(string)
+		if !ok {
+			return nil, fmt.Errorf("expected go mod file to be of type string, got %s", reflect.TypeOf(fileNameInf).String())
+		}
+
+		return modfile.Parse(fileName, []byte(modFile), nil)
+	case "MergeGoMod":
+		return MergeGoMod(t)
+	default:
+		return nil, fmt.Errorf("unknown function %q", t.Name)
+	}
+}
+
+// GetTemplateFunctions serves as a function catalog for the template functions that the
+// stencil-golang plugin exports.
+func (*StencilGolangPlugin) GetTemplateFunctions() ([]*apiv1.TemplateFunction, error) {
+	return []*apiv1.TemplateFunction{
+		{
+			Name:              "ParseGoMod",
+			NumberOfArguments: 2,
+		},
+		{
+			Name:              "MergeGoMod",
+			NumberOfArguments: 4,
+		},
+	}, nil
+}

--- a/manifest.yaml
+++ b/manifest.yaml
@@ -1,5 +1,6 @@
 name: github.com/getoutreach/stencil-golang
-## <<Stencil::Block(keys)>>
+###Block(keys)
+type: templates,extension
 modules:
   - name: github.com/getoutreach/stencil-discovery
 arguments:
@@ -193,4 +194,4 @@ arguments:
       type:
         - string
         - number
-## <</Stencil::Block>>
+###EndBlock(keys)

--- a/plugin/main.go
+++ b/plugin/main.go
@@ -1,0 +1,29 @@
+package main
+
+import (
+	"context"
+	"io"
+
+	goboxlog "github.com/getoutreach/gobox/pkg/log"
+	"github.com/getoutreach/stencil-golang/internal/plugin"
+	"github.com/getoutreach/stencil/pkg/extensions/apiv1"
+	"github.com/sirupsen/logrus"
+)
+
+func main() {
+	// This makes go-plugin very mad
+	goboxlog.SetOutput(io.Discard)
+
+	ctx := context.Background()
+
+	p, err := plugin.NewStencilGolangPlugin(ctx)
+	if err != nil {
+		logrus.WithError(err).Fatal("failed to create extension")
+	}
+
+	logr := logrus.New()
+	logr.SetLevel(logrus.DebugLevel)
+	if err := apiv1.NewExtensionImplementation(p, logr); err != nil {
+		logrus.WithError(err).Fatal("failed to start extension")
+	}
+}

--- a/service.yaml
+++ b/service.yaml
@@ -9,7 +9,8 @@ modules:
 arguments:
   reportingTeam: fnd-dt
   description: Stencil Module for Golang Applications
+  plugin: true
   releaseOptions:
+    force: true
     enablePrereleases: true
-    allowMajorVersions: true
     prereleasesBranch: rc

--- a/stencil.lock
+++ b/stencil.lock
@@ -1,4 +1,4 @@
-version: v1.27.0
+version: v1.28.0-rc.2
 modules:
     - name: github.com/getoutreach/stencil-base
       url: https://github.com/getoutreach/stencil-base
@@ -25,6 +25,9 @@ files:
     - name: .gitignore
       template: .gitignore.tpl
       module: github.com/getoutreach/stencil-base
+    - name: .goreleaser.yml
+      template: .goreleaser.yml.tpl
+      module: github.com/getoutreach/stencil-template-base
     - name: .releaserc.yaml
       template: .releaserc.yaml.tpl
       module: github.com/getoutreach/stencil-base

--- a/templates/.snapshots/TestBasicGoMod-go.mod.tpl-go.mod.snapshot
+++ b/templates/.snapshots/TestBasicGoMod-go.mod.tpl-go.mod.snapshot
@@ -1,0 +1,10 @@
+(*codegen.File)(module github.com/getoutreach/testing
+
+// This is locked to 1.17 to ensure that generics
+// are not in use. This will be removed in the near future.
+// - https://outreach-io.atlassian.net/wiki/spaces/DT/pages/2475294804
+go 1.17
+
+require (
+	github.com/getoutreach/gobox v1.53.2
+))

--- a/templates/.snapshots/TestMergeGoMod-go.mod.tpl-go.mod.snapshot
+++ b/templates/.snapshots/TestMergeGoMod-go.mod.tpl-go.mod.snapshot
@@ -1,4 +1,4 @@
-// This file is used for testing templates
+(*codegen.File)(// This file is used for testing templates
 
 module github.com/getoutreach/stencil-golang
 
@@ -6,9 +6,8 @@ go 1.17
 
 require (
 	github.com/blang/semver/v4 v4.0.0
-	github.com/getoutreach/gobox v1.53.0
+	github.com/getoutreach/gobox v1.53.2
 	github.com/getoutreach/stencil v1.28.0-rc.2
-	github.com/magefile/mage v1.14.0
 	github.com/pkg/errors v0.9.1
 	github.com/sirupsen/logrus v1.9.0
 	golang.org/x/mod v0.6.0-dev.0.20220106191415-9b9b3d81d5e3
@@ -80,4 +79,7 @@ require (
 	gopkg.in/yaml.v3 v3.0.1 // indirect
 	gotest.tools/v3 v3.3.0 // indirect
 	sigs.k8s.io/yaml v1.3.0 // indirect
+)
+
+replace github.com/getoutreach/stencil => ../stencil
 )

--- a/templates/.snapshots/TestRenderDependabot-.github-dependabot.yml.tpl-.github-dependabot.yml.snapshot
+++ b/templates/.snapshots/TestRenderDependabot-.github-dependabot.yml.tpl-.github-dependabot.yml.snapshot
@@ -9,11 +9,6 @@ updates:
     # stencil-golang managed dependencies
     ignore:
       - dependency-name: github.com/getoutreach/gobox
-      - dependency-name: github.com/getoutreach/mint
-      - dependency-name: github.com/getoutreach/httpx
-      - dependency-name: github.com/getoutreach/services
-      - dependency-name: github.com/getoutreach/datastores/v2
-      - dependency-name: github.com/getoutreach/tollmon
       - dependency-name: google.golang.org/grpc
       - dependency-name: github.com/getoutreach/orgservice
 

--- a/templates/.snapshots/testdata/go.mod
+++ b/templates/.snapshots/testdata/go.mod
@@ -8,7 +8,6 @@ require (
 	github.com/blang/semver/v4 v4.0.0
 	github.com/getoutreach/gobox v1.53.0
 	github.com/getoutreach/stencil v1.28.0-rc.2
-	github.com/magefile/mage v1.14.0
 	github.com/pkg/errors v0.9.1
 	github.com/sirupsen/logrus v1.9.0
 	golang.org/x/mod v0.6.0-dev.0.20220106191415-9b9b3d81d5e3
@@ -81,3 +80,5 @@ require (
 	gotest.tools/v3 v3.3.0 // indirect
 	sigs.k8s.io/yaml v1.3.0 // indirect
 )
+
+replace github.com/getoutreach/stencil => ../stencil

--- a/templates/_helpers.tpl
+++ b/templates/_helpers.tpl
@@ -100,28 +100,9 @@
 {{- define "dependencies" }}
 go:
 - name: github.com/getoutreach/gobox
-  version: v1.49.1
-{{- if not (stencil.Arg "oss") }}
-- name: github.com/getoutreach/mint
-  version: v1.51.0
-{{- if eq "honeycomb" (stencil.Arg "tracing") }}
-- name: github.com/getoutreach/httpx
-  version: v1.13.1
-- name: github.com/getoutreach/services
-  version: v1.95.2
-{{- else }}
-- name: github.com/getoutreach/httpx
-  version: v1.16.0
-- name: github.com/getoutreach/services
-  version: v1.101.0
-{{- end }}
-- name: github.com/getoutreach/datastores/v2
-  version: v2.17.0
-{{- end }}
+  version: v1.53.2
 
 {{- if has "grpc" (stencil.Arg "serviceActivities") }}
-- name: github.com/getoutreach/tollmon
-  version: v1.26.0
 - name: google.golang.org/grpc
   version: v1.37.0
 - name: github.com/getoutreach/orgservice
@@ -130,7 +111,16 @@ go:
 
 {{- if stencil.Arg "commands" }}
 - name: github.com/urfave/cli/v2
-  version: v2.3.0
+  version: v2.16.3
+{{- end }}
+
+{{- if stencil.Arg "kubernetes.groups" }}
+- name: k8s.io/apimachinery
+  version: v0.23.0
+- name: k8s.io/client-go
+  version: v0.23.0
+- name: sigs.k8s.io/controller-runtime
+  version: v0.9.6
 {{- end }}
 
 {{- range stencil.GetModuleHook "go_modules" }}
@@ -170,7 +160,7 @@ nodejs:
   - name: "@typescript-eslint/eslint-plugin"
     version: ^2.33.0
   - name: "@typescript-eslint/parser"
-    version: ^4.1.1
+    version: ^2.33.0
   - name: eslint
     version: ^7.13.0
   - name: eslint-config-prettier

--- a/templates/go.mod.tpl
+++ b/templates/go.mod.tpl
@@ -1,7 +1,10 @@
-{{- /* This file is "static" until we have a go extension to generate it" */}}
-{{- $_ := file.Static }}
+{{ file.Skip "Virtual file to generate go.mod" }}
+{{- define "go.mod" -}}
 module github.com/{{ .Runtime.Box.Org }}/{{ .Config.Name }}
 
+// This is locked to 1.17 to ensure that generics
+// are not in use. This will be removed in the near future.
+// - https://outreach-io.atlassian.net/wiki/spaces/DT/pages/2475294804
 go 1.17
 
 require (
@@ -9,3 +12,20 @@ require (
 	{{ $d.name }} {{ $d.version }}
 	{{- end }}
 )
+
+{{- end -}}
+
+# Render the go mod file, use it if we don't have an existing go.mod
+{{ $newGoMod := (stencil.ApplyTemplate "go.mod") }}
+{{ $goModContents := $newGoMod }}
+{{ file.Create "go.mod" 0600 now }}
+
+# If the go.mod already exists, merge it with the generated one
+# then write it to disk.
+{{- if stencil.Exists "go.mod" }}
+  {{ $existingGoMod := stencil.ReadFile "go.mod" }}
+  {{ $goModContents = (extensions.Call "github.com/getoutreach/stencil-golang.MergeGoMod" "go.mod" $existingGoMod "go.generate.mod" $newGoMod) }}
+{{- end }}
+
+# Write out the go.mod
+{{ file.SetContents $goModContents }}


### PR DESCRIPTION
<!--
  !!!! README !!!! Please fill this out.

  Please follow the PR naming conventions:
  https://outreach-io.atlassian.net/wiki/spaces/EN/pages/1902444645/Conventional+Commits
-->

<!-- A short description of what your PR does and what it solves. -->

## What this PR does / why we need it

This PR migrates the original bootstrap `go.mod` processor to stencil, in a stencil native way (a extension!). This PR contains the new go module "processor" (extension) and the `go.mod` template code needed to use it.

This `go.mod` function merges the on disk `go.mod` with a generated one from dependencies from module hooks, and baked in dependencies. This is done by adding a extension with `MergeGoMod` that merges the right hand `go.mod` into the left hand one, keeping dependencies if they are higher than the right hand `go.mod`
<!-- <<Stencil::Block(jiraPrefix)>> -->

## Jira ID

[DT-2093]

<!-- <</Stencil::Block>> -->

<!-- Notes that may be helpful for anyone reviewing this PR -->

## Notes for your reviewers

<!-- <<Stencil::Block(custom)>> -->

<!-- <</Stencil::Block>> -->


[DT-2093]: https://outreach-io.atlassian.net/browse/DT-2093?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ