### PR TITLE
fix(go.mod): prefix version with a v if not provided

### DIFF
--- a/templates/go.mod.tpl
+++ b/templates/go.mod.tpl
@@ -9,7 +9,7 @@ go 1.17
 
 require (
 	{{- range $d := (stencil.ApplyTemplate "dependencies" | fromYaml).go }}
-	{{ $d.name }} {{ $d.version }}
+	{{ $d.name }} {{ hasPrefix "v" $d.version | ternary "" "v" }}{{ $d.version }}
 	{{- end }}
 )
 


### PR DESCRIPTION
<!--
  !!!! README !!!! Please fill this out.

  Please follow the PR naming conventions:
  https://outreach-io.atlassian.net/wiki/spaces/EN/pages/1902444645/Conventional+Commits
-->

<!-- A short description of what your PR does and what it solves. -->

## What this PR does / why we need it

This PR prefixes versions provided with a `v` if they don't have one. This would break on branches, but I can't imagine someone passing a branch through a stencil module...

<!-- <<Stencil::Block(jiraPrefix)>> -->

## Jira ID

[DT-2808]

<!-- <</Stencil::Block>> -->

<!-- Notes that may be helpful for anyone reviewing this PR -->

## Notes for your reviewers

<!-- <<Stencil::Block(custom)>> -->

<!-- <</Stencil::Block>> -->


[DT-2808]: https://outreach-io.atlassian.net/browse/DT-2808?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ