### PR TITLE
fix: Exclude panic alert from devenv

### DIFF
--- a/templates/monitoring/datadog.tf.tpl
+++ b/templates/monitoring/datadog.tf.tpl
@@ -129,7 +129,7 @@ resource "datadog_monitor" "available_pods_low" {
 resource "datadog_monitor" "panics" {
   type    = "log alert"
   name    = "{{ .Config.Name | title }} Service panics"
-  query   = "logs(\"panic status:error service:{{ .Config.Name }} -env:development\").index(\"*\").rollup(\"count\").by(\"kube_namespace\").last(\"5m\") > 0"
+  query   = "logs(\"panic status:error service:{{ .Config.Name }} -env:development -@k8s_namespace:*devenv*\").index(\"*\").rollup(\"count\").by(\"kube_namespace\").last(\"5m\") > 0"
   tags    = local.ddTags
   message = <<EOF
   Log based monitor of runtime error panics.


### PR DESCRIPTION
<!--
  !!!! README !!!! Please fill this out.

  Please follow the PR naming conventions:
  https://outreach-io.atlassian.net/wiki/spaces/EN/pages/1902444645/Conventional+Commits
-->

<!-- A short description of what your PR does and what it solves. -->

## What this PR does / why we need it
We got a P1 alert caused by a panic from devenv. https://app.datadoghq.com/logs?cols=%40level%2Cservice%2C%40or.voice_trace_id%2C%40usr.email%2C%40k8s_namespace&event&from_ts=1664574860854&index=&live=false&messageDisplay=inline&query=panic+-%22Workflow+panic%22+status%3Aerror+service%3Atwiliowebhook+-env%3Adevelopment&stream_sort=time%2Casc&to_ts=1664575402855&viz=stream

We want to exclude those alerts.

<!-- <<Stencil::Block(jiraPrefix)>> -->

## Jira ID

[XX-XX]

<!-- <</Stencil::Block>> -->

<!-- Notes that may be helpful for anyone reviewing this PR -->

## Notes for your reviewers

<!-- <<Stencil::Block(custom)>> -->

<!-- <</Stencil::Block>> -->
