### PR TITLE
feat: exclude goconst linter in tests

### DIFF
--- a/templates/scripts/golangci.yml.tpl
+++ b/templates/scripts/golangci.yml.tpl
@@ -104,6 +104,7 @@ issues:
         - gosec
         - funlen
         - gochecknoglobals # Globals in test files are tolerated.
+        - goconst # Repeated consts in test files are tolerated.
     # This rule is buggy and breaks on our `///Block` lines.  Disable for now.
     - linters:
         - gocritic


### PR DESCRIPTION
<!-- A short description of what your PR does and what it solves. -->

Repeating consts in tests is a normal pattern and the linter should not complain about this, so this change excludes it. See this thread: https://outreach-hq.slack.com/archives/CM3TW594L/p1664580535961139

<!-- <<Stencil::Block(jiraPrefix)>> -->

## Jira ID

[DT-2947](https://outreach-io.atlassian.net/browse/DT-2947)

<!-- <</Stencil::Block>> -->



[DT-2947]: https://outreach-io.atlassian.net/browse/DT-2947?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ