### PR TITLE
fix(golangci-lint): remove older severity rules that applied to fork

### DIFF
--- a/templates/scripts/golangci.yml.tpl
+++ b/templates/scripts/golangci.yml.tpl
@@ -2,20 +2,6 @@
 lintroller:
   tier: "{{ stencil.Arg "lintroller" }}"
 
-severity:
-  default-severity: error
-  case-sensitive: false
-  rules:
-    - severity: warning
-      # New rule, add as warning for now
-      text: "^(redundantSprint|ioutilDeprecated|octalLiteral):"
-      linters:
-        - gocritic
-    - severity: warning
-      # New rule, add as warning for now
-      linters:
-        - errorlint
-
 # Linter settings
 linters-settings:
   errcheck:


### PR DESCRIPTION
<!--
  !!!! README !!!! Please fill this out.

  Please follow the PR naming conventions:
  https://outreach-io.atlassian.net/wiki/spaces/EN/pages/1902444645/Conventional+Commits
-->

<!-- A short description of what your PR does and what it solves. -->

## What this PR does / why we need it

Removes config lines that only applied to our fork of golangci-lint we stopped using.

<!-- <<Stencil::Block(jiraPrefix)>> -->

## Jira ID

[XX-XX]

<!-- <</Stencil::Block>> -->

<!-- Notes that may be helpful for anyone reviewing this PR -->

## Notes for your reviewers

<!-- <<Stencil::Block(custom)>> -->

<!-- <</Stencil::Block>> -->
