### PR TITLE
fix(linters): Disable the timeCmpSimplify linter.

### DIFF
--- a/templates/scripts/golangci.yml.tpl
+++ b/templates/scripts/golangci.yml.tpl
@@ -34,6 +34,7 @@ linters-settings:
       - style
     disabled-checks:
       - whyNoLint # Doesn't seem to work properly
+      - timeCmpSimplify # Suggests bad simplifications (After is not identical to !Before).
   funlen:
     lines: 500
     statements: 50

--- a/templates/scripts/golangci.yml.tpl
+++ b/templates/scripts/golangci.yml.tpl
@@ -34,7 +34,10 @@ linters-settings:
       - style
     disabled-checks:
       - whyNoLint # Doesn't seem to work properly
-      - timeCmpSimplify # Suggests bad simplifications (After is not identical to !Before).
+      # Suggests bad simplifications (After is not identical to !Before).
+      # TODO(jkinkead): Remove when we have a version of go-critic with
+      # https://github.com/go-critic/go-critic/pull/1281 merged.
+      - timeCmpSimplify
   funlen:
     lines: 500
     statements: 50


### PR DESCRIPTION
## What this PR does / why we need it

`timeCmpSimplify` recommends that you replace `!time.Before()` with `time.After()`, but these are not actually compatible (strictly-less being replaced with strictly-greater). Same with `!time.After()` and `time.Before()`.
