### PR TITLE
fix: remove @outreach/prettier-config from node client

### DIFF
--- a/templates/.snapshots/TestRenderDependabot-.github-dependabot.yml.tpl-.github-dependabot.yml.snapshot
+++ b/templates/.snapshots/TestRenderDependabot-.github-dependabot.yml.tpl-.github-dependabot.yml.snapshot
@@ -35,7 +35,6 @@ updates:
       - dependency-name: "ts-enum-util"
       - dependency-name: "winston"
       - dependency-name: "@outreach/eslint-config"
-      - dependency-name: "@outreach/prettier-config"
       - dependency-name: "@types/jest"
       - dependency-name: "@typescript-eslint/eslint-plugin"
       - dependency-name: "@typescript-eslint/parser"

--- a/templates/_helpers.tpl
+++ b/templates/_helpers.tpl
@@ -151,8 +151,6 @@ nodejs:
   devDependencies:
   - name: "@outreach/eslint-config"
     version: ^1.0.4
-  - name: "@outreach/prettier-config"
-    version: ^1.0.3
   - name: "@types/jest"
     version: ^26.0.15
   - name: "@typescript-eslint/eslint-plugin"

--- a/templates/api/clients/node/package.hjson.tpl
+++ b/templates/api/clients/node/package.hjson.tpl
@@ -49,7 +49,6 @@
     "test-ci": "NODE_ENV=test jest \"./src/\"",
     "tsc": "node -r tsconfig-paths/register ./node_modules/.bin/tsc -p tsconfig.production.json && node ./scripts/copy-definitions.js"
   },
-  "prettier": "@outreach/prettier-config",
   "moduleDirectories": [
     "node_modules",
     "src"


### PR DESCRIPTION
<!--
  !!!! README !!!! Please fill this out.

  Please follow the PR naming conventions:
  https://outreach-io.atlassian.net/wiki/spaces/EN/pages/1902444645/Conventional+Commits
-->

<!-- A short description of what your PR does and what it solves. -->

## What this PR does / why we need it

We stopped using this elsewhere, but it was left behind in the node client.

<!-- <<Stencil::Block(jiraPrefix)>> -->

## Jira ID

[XX-XX]

<!-- <</Stencil::Block>> -->

<!-- Notes that may be helpful for anyone reviewing this PR -->

## Notes for your reviewers

<!-- <<Stencil::Block(custom)>> -->

<!-- <</Stencil::Block>> -->
