### PR TITLE
fix(k8s): error if controller-gen fails

### DIFF
--- a/templates/api/kubernetes/version.go.tpl
+++ b/templates/api/kubernetes/version.go.tpl
@@ -10,7 +10,7 @@
 package {{ .version }}
 
 //nolint:lll //Why: Long shell script
-//go:generate /usr/bin/env bash -c "pushd ../../..{{if not (empty .package)}}/..{{end}} >/dev/null 2>&1 && ./scripts/shell-wrapper.sh gobin.sh sigs.k8s.io/controller-tools/cmd/controller-gen@v0.7.0 object paths=./api/k8s/{{ .package }}/{{ .version }}; popd >/dev/null 2>&1"
+//go:generate /usr/bin/env bash -e -c "pushd ../../..{{if not (empty .package)}}/..{{end}} >/dev/null 2>&1 && ./scripts/shell-wrapper.sh gobin.sh sigs.k8s.io/controller-tools/cmd/controller-gen@v0.7.0 object paths=./api/k8s/{{ .package }}/{{ .version }}; popd >/dev/null 2>&1"
 {{ end }}
 
 {{- range $g := stencil.Arg "kubernetes.groups" }}

--- a/templates/api/kubernetes/version.go.tpl
+++ b/templates/api/kubernetes/version.go.tpl
@@ -10,7 +10,7 @@
 package {{ .version }}
 
 //nolint:lll //Why: Long shell script
-//go:generate /usr/bin/env bash -e -c "pushd ../../..{{if not (empty .package)}}/..{{end}} >/dev/null 2>&1 && ./scripts/shell-wrapper.sh gobin.sh sigs.k8s.io/controller-tools/cmd/controller-gen@v0.7.0 object paths=./api/k8s/{{ .package }}/{{ .version }}; popd >/dev/null 2>&1"
+//go:generate /usr/bin/env bash -c "pushd ../../..{{if not (empty .package)}}/..{{end}} >/dev/null 2>&1 && ./scripts/shell-wrapper.sh gobin.sh sigs.k8s.io/controller-tools/cmd/controller-gen@v0.7.0 object paths=./api/k8s/{{ .package }}/{{ .version }} && popd >/dev/null 2>&1"
 {{ end }}
 
 {{- range $g := stencil.Arg "kubernetes.groups" }}


### PR DESCRIPTION
<!--
  !!!! README !!!! Please fill this out.

  Please follow the PR naming conventions:
  https://outreach-io.atlassian.net/wiki/spaces/EN/pages/1902444645/Conventional+Commits
-->

<!-- A short description of what your PR does and what it solves. -->

## What this PR does / why we need it
- Adds the `-e` option to the bash invocation in the `go:generate` comment for Kubernetes controller code-gen
- Without the `-e`, bash will silently eat any errors from `controller-gen`

<!-- <<Stencil::Block(jiraPrefix)>> -->

## Jira ID

[QSS-1430]

<!-- <</Stencil::Block>> -->

<!-- Notes that may be helpful for anyone reviewing this PR -->

## Notes for your reviewers

<!-- <<Stencil::Block(custom)>> -->

<!-- <</Stencil::Block>> -->

Before change:
```
❯ make gogenerate
 :: Running gogenerate
github.com/getoutreach/database-provisioning-operator/api/k8s/database/v1:-: name requested for invalid type: interface{}
github.com/getoutreach/database-provisioning-operator/api/k8s/database/v1:-: invalid map value type: interface{}
Error: not all generators ran successfully
run `controller-gen object paths=./api/k8s/database/v1 -w` to see all available markers, or `controller-gen object paths=./api/k8s/database/v1 -h` for usage

❯ echo $?
0
``` 

after change:
```
❯ make gogenerate
 :: Running gogenerate
github.com/getoutreach/database-provisioning-operator/api/k8s/database/v1:-: name requested for invalid type: interface{}
github.com/getoutreach/database-provisioning-operator/api/k8s/database/v1:-: invalid map value type: interface{}
Error: not all generators ran successfully
run `controller-gen object paths=./api/k8s/database/v1 -w` to see all available markers, or `controller-gen object paths=./api/k8s/database/v1 -h` for usage
api/k8s/database/v1/v1.go:10: running "/usr/bin/env": exit status 1
make: *** [gogenerate] Error 1
```

[QSS-1430]: https://outreach-io.atlassian.net/browse/QSS-1430?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ