### PR TITLE
fix: move terraform version to be owned by golang

### DIFF
--- a/manifest.yaml
+++ b/manifest.yaml
@@ -193,4 +193,9 @@ arguments:
       type:
         - string
         - number
+  versions.terraform:
+    schema:
+      type: string
+    default: "0.14.11"
+    description: The version of terraform that is used.
 ###EndBlock(keys)

--- a/templates/_helpers.tpl
+++ b/templates/_helpers.tpl
@@ -17,7 +17,7 @@
 - name: nodejs
   version: 16.13.0
 - name: terraform
-  version: 0.13.5
+  version: {{ stencil.Arg "versions.terraform" }}
 # Just in case bundler/etc needs to be used in the root.
 - name: ruby
   version: 2.7.5


### PR DESCRIPTION
<!--
  !!!! README !!!! Please fill this out.

  Please follow the PR naming conventions:
  https://outreach-io.atlassian.net/wiki/spaces/EN/pages/1902444645/Conventional+Commits
-->

<!-- A short description of what your PR does and what it solves. -->

## What this PR does / why we need it
This PR moves terraform version mgmt to stencil-golang as per discussion here: https://outreach-hq.slack.com/archives/CN9MU7GLW/p1668191998007089. Another PR pending on stencil-outreach to hook into the golang's version of the terraform instead of redeclaring it.

This PR also bumps the default from 0.13.5  to 0.14.11. If somebody has an issue with it, please do not revert the PR and instead force the version backwards in your service.yaml using the arguments -> versions -> terraform field.

Reason for a bump: clerk and smartstore has provisioned dashboards that rely on 0.14 experiments and functionality.

<!-- <<Stencil::Block(jiraPrefix)>> -->

## Jira ID

[CDT-104]

<!-- <</Stencil::Block>> -->

<!-- Notes that may be helpful for anyone reviewing this PR -->

## Notes for your reviewers
Also tested on https://github.com/getoutreach/pgtestservice/pull/38 - clerk and smartstore terraforms were applied successfully using terraform 0.14.11.

<!-- <<Stencil::Block(custom)>> -->

<!-- <</Stencil::Block>> -->


[CDT-104]: https://outreach-io.atlassian.net/browse/CDT-104?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ