### PR TITLE
feat: add module hook for devspace app profiles

### DIFF
--- a/docs/module-hooks.md
+++ b/docs/module-hooks.md
@@ -133,3 +133,45 @@ Extra configuration jsonnet files to merge into the application config.
 {{ $myConfig := "my-config" }}
 {{ stencil.AddToModuleHook "github.com/getoutreach/stencil-golang" "app.config.jsonnet/config" (list $myConfig) }}
 ```
+
+### `devspace.profiles`
+
+**Type**: 
+```
+{ 
+   name: string, 
+   description: string, 
+   activation: 
+      env: [ key: value ]
+      vars: [ key: value ]
+   patches:
+      [
+        {
+          op: string
+          path: string
+          value: [ key: value ]
+        }
+      ]
+```
+
+**File**: `devspace.yaml.tpl`
+
+Extra [devspace profiles](https://www.devspace.sh/docs/5.x/configuration/profiles/basics) to merge into the devspace.yaml config. 
+
+```tpl
+{{- define "ingestTerminalDevspaceProfile" }}
+- name: {{ .Config.Name }}-ingest-terminal
+  description: Allows for running ingest in --with-terminal mode
+  activation:
+    - env:
+        DEVENV_DEV_DEPLOYMENT_PROFILE: deployment__{{ .Config.Name }}-ingest
+        DEVENV_DEV_TERMINAL: "true"
+  patches:
+    - op: replace
+      path: dev.terminal.labelSelector
+      value:
+        app: {{ .Config.Name }}-ingest
+{{- end }}
+
+{{ stencil.AddToModuleHook "github.com/getoutreach/stencil-golang" "devspace.profiles" (stencil.ApplyTemplate "ingestDevspaceProfile" | fromYaml) }}
+```

--- a/templates/devspace.yaml.tpl
+++ b/templates/devspace.yaml.tpl
@@ -447,6 +447,21 @@ profiles:
       - vars:
           DEVENV_DEV_DEPLOYMENT_PROFILE: deployment__{{ .Config.Name }}
 
+{{- range (stencil.GetModuleHook "devspace.profiles") }}
+  - name: {{ .name }}
+    {{- if .description }}
+    description: {{ .description }}
+    {{- end }}
+    activation:
+      {{- if .activation }}
+{{ toYaml .activation | indent 6 }}
+      {{- end }}
+    {{- if .patches }}
+    patches:
+{{ toYaml .patches | indent 6 }}
+    {{- end }}
+{{- end }}
+
   ## <<Stencil::Block(profiles)>>
 {{ file.Block "profiles" }}
   ## <</Stencil::Block>>


### PR DESCRIPTION
<!--
  !!!! README !!!! Please fill this out.

  Please follow the PR naming conventions: 
  https://outreach-io.atlassian.net/wiki/spaces/EN/pages/1902444645/Conventional+Commits
-->


<!-- A short description of what your PR does and what it solves. -->
## What this PR does / why we need it
Adds a module hook to allow other modules to register devspace app profiles.  See video for scenario.

Video: https://share.getcloudapp.com/nOu1mPJr

<!-- <<Stencil::Block(jiraPrefix)>> -->

## Jira ID

[XX-XX]

<!-- <</Stencil::Block>> -->

<!-- Notes that may be helpful for anyone reviewing this PR -->
## Notes for your reviewers



<!-- <<Stencil::Block(custom)>> -->

<!-- <</Stencil::Block>> -->
