### PR TITLE
feat: add module hooks to server template

### DIFF
--- a/docs/module-hooks.md
+++ b/docs/module-hooks.md
@@ -175,3 +175,49 @@ Extra [devspace profiles](https://www.devspace.sh/docs/5.x/configuration/profile
 
 {{ stencil.AddToModuleHook "github.com/getoutreach/stencil-golang" "devspace.profiles" (stencil.ApplyTemplate "ingestDevspaceProfile" | fromYaml) }}
 ```
+
+### `internal/rpc/server.additionalImports`
+
+**Type**: `string`
+
+**File**: `internal/appName/rpc/server.go.tpl`
+
+```tpl
+{{ define "imports" }}
+"sync"
+
+"github.com/getoutreach/outreachtest/pkg/logrecorder"
+"{{ stencil.ApplyTemplate "appImportPath" }}/api"
+{{ end }}
+
+{{ stencil.AddToModuleHook "github.com/getoutreach/stencil-golang" "internal/rpc/server.additionalImports" (list (stencil.ApplyTemplate "imports")) }}
+```
+
+### `internal/rpc/server.additionalHanderState`
+
+**Type**: `string`
+
+**File**: `internal/appName/rpc/server.go.tpl`
+
+```tpl
+{{ define "handlerState" }}
+config *Config
+result *api.TestRunResponse
+{{ end }}
+
+{{ stencil.AddToModuleHook "github.com/getoutreach/stencil-golang" "internal/rpc/server.additionalHandlerState" (list (stencil.ApplyTemplate "handlerState")) }}
+```
+
+### `internal/rpc/server.additionalProperties`
+
+**Type**: `string`
+
+**File**: `internal/appName/rpc/server.go.tpl`
+
+```tpl
+{{ define "properties" }}
+config: cfg,
+{{ end }}
+
+{{ stencil.AddToModuleHook "github.com/getoutreach/stencil-golang" "internal/rpc/server.additionalProperties" (list (stencil.ApplyTemplate "properties")) }}
+```

--- a/templates/.snapshots/TestRenderAPIGoSuccess-api-api.go.tpl-api-testing.go.snapshot
+++ b/templates/.snapshots/TestRenderAPIGoSuccess-api-api.go.tpl-api-testing.go.snapshot
@@ -1,5 +1,5 @@
 (*codegen.File)(<nil>
-// Copyright 2022 Outreach Corporation. All Rights Reserved.
+// Copyright 2023 Outreach Corporation. All Rights Reserved.
 
 // Description: This file defines the gRPC server service interface for
 // testing.

--- a/templates/.snapshots/TestRenderDeploymentConfig-deployments-appname-app.config.jsonnet.tpl-deployments-testing-testing.config.jsonnet.snapshot
+++ b/templates/.snapshots/TestRenderDeploymentConfig-deployments-appname-app.config.jsonnet.tpl-deployments-testing-testing.config.jsonnet.snapshot
@@ -1,4 +1,4 @@
-(*codegen.File)(// Copyright 2022 Outreach Corporation. All Rights Reserved.
+(*codegen.File)(// Copyright 2023 Outreach Corporation. All Rights Reserved.
 //
 // Managed: true
 

--- a/templates/.snapshots/TestRenderDeploymentJsonnet-deployments-appname-app.jsonnet.tpl-deployments-testing-testing.jsonnet.snapshot
+++ b/templates/.snapshots/TestRenderDeploymentJsonnet-deployments-appname-app.jsonnet.tpl-deployments-testing-testing.jsonnet.snapshot
@@ -1,5 +1,5 @@
 (*codegen.File)(
-// Copyright 2022 Outreach Corporation. All Rights Reserved.
+// Copyright 2023 Outreach Corporation. All Rights Reserved.
 //
 // Managed: true
 

--- a/templates/.snapshots/TestRenderDeploymentOverride-deployments-appname-app.override.jsonnet.tpl-deployments-testing-testing.override.jsonnet.snapshot
+++ b/templates/.snapshots/TestRenderDeploymentOverride-deployments-appname-app.override.jsonnet.tpl-deployments-testing-testing.override.jsonnet.snapshot
@@ -1,4 +1,4 @@
-(*codegen.File)(// Copyright 2022 Outreach Corporation. All Rights Reserved.
+(*codegen.File)(// Copyright 2023 Outreach Corporation. All Rights Reserved.
 //
 // Description: This file is automatically merged into the 'testing.jsonnet' file.
 // Configuration should go into the 'testing.config.jsonnet' file, or in the relevant

--- a/templates/internal/appName/rpc/server.go.tpl
+++ b/templates/internal/appName/rpc/server.go.tpl
@@ -13,6 +13,12 @@ package {{ stencil.ApplyTemplate "goPackageSafeName" }} //nolint:revive // Why: 
 
 import (
 	"context"
+  {{- $additionalImports := stencil.GetModuleHook "internal/rpc/server.additionalImports" }}
+  {{- if $additionalImports }}
+      {{- range $additionalImports -}}
+  {{ . | indent 2 }}
+      {{- end }}
+  {{- end }}
 )
 
 // Server is the actual server implementation of the API.
@@ -20,12 +26,32 @@ import (
 // Note that tracing, logging and metrics are already handled for these
 // methods.
 type Server struct{
+  {{- $additionalHandlerState := stencil.GetModuleHook "internal/rpc/server.additionalHandlerState" }}
+  {{- if $additionalHandlerState }}
+  // handler state added my modules
+    {{- range $additionalHandlerState -}}
+  {{ . | indent 2 }}
+    {{- end -}}
+  // end handler state added by modules
+  {{- end }}
+
 	// Place any handler state for your service here.
 }
 
 // NewServer creates a new server instance.
 func NewServer(ctx context.Context, cfg *Config) (*Server, error) {
+  {{- $additionalProperties := stencil.GetModuleHook "internal/rpc/server.additionalProperties" }}
+  {{- if $additionalProperties }}
+    return &Server{
+      // properties added by modules
+    {{- range $additionalProperties -}}
+      {{ . | indent 6 }}
+    {{- end -}}
+      // end properties added by modules
+    }, nil
+  {{- else }}
 	return &Server{}, nil
+  {{- end }}
 }
 
 // Ping is a simple ping endpoint that returns "pong" + message when called


### PR DESCRIPTION
<!--
  !!!! README !!!! Please fill this out.

  Please follow the PR naming conventions: 
  https://outreach-io.atlassian.net/wiki/spaces/EN/pages/1902444645/Conventional+Commits
-->


<!-- A short description of what your PR does and what it solves. -->
## What this PR does / why we need it

Adds 3 module hooks to the server template for:
- Additional imports
- Additional handler state in the `Server` struct
- Additional properties passed to the initial instantiation of the `Server` struct

I am building a [new stencil module for E2E test repos](https://github.com/getoutreach/stencil-outreachtest) and have a need to inject additional imports and properties for the server. Originally, I was [overwriting the server file with my own generated template](https://github.com/getoutreach/stencil-outreachtest/blob/main/templates/internal/appName/rpc/server.go.tpl), but that is not best practice since it has the likelihood of leading to errors in the future.

<!-- <<Stencil::Block(jiraPrefix)>> -->

## Jira ID

[XX-XX]

<!-- <</Stencil::Block>> -->

<!-- Notes that may be helpful for anyone reviewing this PR -->
## Notes for your reviewers



<!-- <<Stencil::Block(custom)>> -->

<!-- <</Stencil::Block>> -->
