### PR TITLE
feat: [ORES-1803] Switch to be able to turn of grpc proto generation

### DIFF
--- a/manifest.yaml
+++ b/manifest.yaml
@@ -222,4 +222,8 @@ arguments:
       type: string
     default: "0.14.11"
     description: The version of terraform that is used.
+  disableGrpcGeneration:
+    description: Disable gRPC generation if you are using protoAPI generation
+    schema:
+      type: boolean
 ## <</Stencil::Block>>

--- a/templates/api/rpc_helpers.go.tpl
+++ b/templates/api/rpc_helpers.go.tpl
@@ -13,6 +13,8 @@
 // which implements a cleaner interface.
 package api
 
+{{- if not (stencil.Arg "disableGrpcGeneration") }}
 // The following line(s) generate code using protobuf (e.g. {{ .Config.Name }}.pb.go)
 //
 //go:generate ../scripts/shell-wrapper.sh protoc.sh
+{{- end }}


### PR DESCRIPTION
<!--
  !!!! README !!!! Please fill this out.

  Please follow the PR naming conventions: 
  https://outreach-io.atlassian.net/wiki/spaces/EN/pages/1902444645/Conventional+Commits
-->


<!-- A short description of what your PR does and what it solves. -->
## What this PR does / why we need it

To be able to use properly protoAPI we need to be able to switch off protoc generation from golang module.

<!-- <<Stencil::Block(jiraPrefix)>> -->

## Jira ID

[ORES-1803]

<!-- <</Stencil::Block>> -->

<!-- Notes that may be helpful for anyone reviewing this PR -->
## Notes for your reviewers



<!-- <<Stencil::Block(custom)>> -->

<!-- <</Stencil::Block>> -->


[ORES-1803]: https://outreach-io.atlassian.net/browse/ORES-1803?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ