### PR TITLE
feat: add module hook to add make commands

### DIFF
--- a/docs/module-hooks.md
+++ b/docs/module-hooks.md
@@ -198,10 +198,14 @@ Extra ports that should be forwarded while `devspace dev` is running
 Extra commands to add to the root Makefile
 
 ```tpl
+{{- define "run.rover" }}
 ## run-rover:           merges shared and specific schemas and runs rover-cli 
 .PHONY: run-rover
 run-rover:
-    cat internal/graphql/schema/shared.graphql > internal/graphql/generated/schema.graphql
-    cat internal/graphql/schema/schema.graphql >> internal/graphql/generated/schema.graphql
-    rover dev --router-config config/apollo.yaml --name rogue --url http://localhost:4000/graphql --schema internal/graphql/generated/schema.graphql
+	cat internal/graphql/schema/shared.graphql > internal/graphql/generated/schema.graphql
+	cat internal/graphql/schema/schema.graphql >> internal/graphql/generated/schema.graphql
+	rover dev --router-config config/apollo.yaml --name $appName --url http://localhost:4000/graphql --schema internal/graphql/generated/schema.graphql
+{{- end }}
+
+{{- stencil.AddToModuleHook "github.com/getoutreach/stencil-golang" "Makefile.commands" (list (stencil.ApplyTemplate "run.rover")) }}
 ```

--- a/docs/module-hooks.md
+++ b/docs/module-hooks.md
@@ -188,3 +188,20 @@ Extra ports that should be forwarded while `devspace dev` is running
 # devspace.ports
 {{- stencil.AddToModuleHook "github.com/getoutreach/stencil-golang" "devspace.ports" (list "4000") }}
 ```
+
+### `Makefile.commands`
+
+**Type**: `string`
+
+**File**: `Makefile`
+
+Extra commands to add to the root Makefile
+
+```tpl
+## run-rover:           merges shared and specific schemas and runs rover-cli 
+.PHONY: run-rover
+run-rover:
+    cat internal/graphql/schema/shared.graphql > internal/graphql/generated/schema.graphql
+    cat internal/graphql/schema/schema.graphql >> internal/graphql/generated/schema.graphql
+    rover dev --router-config config/apollo.yaml --name rogue --url http://localhost:4000/graphql --schema internal/graphql/generated/schema.graphql
+```

--- a/templates/Makefile.tpl
+++ b/templates/Makefile.tpl
@@ -4,6 +4,10 @@ _ := $(shell ./scripts/devbase.sh)
 
 include .bootstrap/root/Makefile
 
+{{- range (stencil.GetModuleHook "Makefile.commands") }}
+{{ . }}
+{{- end }}
+
 ## <<Stencil::Block(targets)>>
 {{ file.Block "targets" }}
 ## <</Stencil::Block>>


### PR DESCRIPTION
<!--
  !!!! README !!!! Please fill this out.

  Please follow the PR naming conventions: 
  https://outreach-io.atlassian.net/wiki/spaces/EN/pages/1902444645/Conventional+Commits
-->


<!-- A short description of what your PR does and what it solves. -->
## What this PR does / why we need it
Adds a module hook to allow other modules to add Make commands to the root Makefile.

Allows `stencil-graphql` to add a command for running the rover-cli for dev work.


<!-- <<Stencil::Block(jiraPrefix)>> -->

## Jira ID

[XX-XX]

<!-- <</Stencil::Block>> -->

<!-- Notes that may be helpful for anyone reviewing this PR -->
## Notes for your reviewers



<!-- <<Stencil::Block(custom)>> -->

<!-- <</Stencil::Block>> -->
