### PR TITLE
feat: add module hook to allow for extra forwarded ports in devspace

### DIFF
--- a/docs/module-hooks.md
+++ b/docs/module-hooks.md
@@ -175,3 +175,16 @@ Extra [devspace profiles](https://www.devspace.sh/docs/5.x/configuration/profile
 
 {{ stencil.AddToModuleHook "github.com/getoutreach/stencil-golang" "devspace.profiles" (stencil.ApplyTemplate "ingestDevspaceProfile" | fromYaml) }}
 ```
+
+### `devspace.ports`
+
+**Type**: `string`
+
+**File**: `devspace.yaml.tpl`
+
+Extra ports that should be forwarded while `devspace dev` is running
+
+```tpl
+# devspace.ports
+{{- stencil.AddToModuleHook "github.com/getoutreach/stencil-golang" "devspace.ports" (list "4000") }}
+```

--- a/templates/devspace.yaml.tpl
+++ b/templates/devspace.yaml.tpl
@@ -139,6 +139,9 @@ dev:
 {{- if (has "http" (stencil.Arg "serviceActivities")) }}
         - port: 8080
 {{- end }}
+{{- range (stencil.GetModuleHook "devspace.ports") }}
+        - port: {{ . }}
+{{- end }}
         # Remote debugging port
         - port: ${DLV_PORT}
 


### PR DESCRIPTION
<!--
  !!!! README !!!! Please fill this out.

  Please follow the PR naming conventions: 
  https://outreach-io.atlassian.net/wiki/spaces/EN/pages/1902444645/Conventional+Commits
-->


<!-- A short description of what your PR does and what it solves. -->
## What this PR does / why we need it
Allows for adding extra forwarded ports durning `devenv apps run`.  Needed to add port graphql is running on.


<!-- <<Stencil::Block(jiraPrefix)>> -->

## Jira ID

[XX-XX]

<!-- <</Stencil::Block>> -->

<!-- Notes that may be helpful for anyone reviewing this PR -->
## Notes for your reviewers



<!-- <<Stencil::Block(custom)>> -->

<!-- <</Stencil::Block>> -->
