### PR TITLE
feat: added ChannelOptions param to client-helpers ClientOptions

### DIFF
--- a/templates/api/clients/node/src/client-helpers.ts.tpl
+++ b/templates/api/clients/node/src/client-helpers.ts.tpl
@@ -22,6 +22,10 @@ export interface ClientOptions {
 
   /** This is the gRPC interceptors that should be run on messages passed through the client. */
   interceptors?: grpc.Interceptor[];
+
+  /** This is the ChannelOptions map for overriding default grpc-js ChannelOptions values. */
+  /* eslint-disable @typescript-eslint/no-explicit-any */
+  channelOptions?: Map<string, any> | null;
 }
 
 /**
@@ -38,6 +42,6 @@ export function create{{ stencil.ApplyTemplate "serviceNameLanguageSafe" }}Clien
   if (options?.interceptors) {
     interceptors.push(...options.interceptors);
   }
-
-  return new {{ stencil.ApplyTemplate "serviceNameLanguageSafe" }}Client(endpoint, grpc.credentials.createInsecure(), { interceptors });
+  const channelOptions = options?.channelOptions;
+  return new {{ stencil.ApplyTemplate "serviceNameLanguageSafe" }}Client(endpoint, grpc.credentials.createInsecure(), { interceptors, channelOptions });
 }


### PR DESCRIPTION
<!--
  !!!! README !!!! Please fill this out.

  Please follow the PR naming conventions: 
  https://outreach-io.atlassian.net/wiki/spaces/EN/pages/1902444645/Conventional+Commits
-->


<!-- A short description of what your PR does and what it solves. -->
## What this PR does / why we need it

This change allows developers to pass in [ChannelOptions](https://github.com/grpc/grpc-node/blob/master/packages/grpc-js/src/channel-options.ts#L23) during node client initialization.

<!-- <<Stencil::Block(jiraPrefix)>> -->

## Jira ID

[XX-XX]

<!-- <</Stencil::Block>> -->

<!-- Notes that may be helpful for anyone reviewing this PR -->
## Notes for your reviewers



<!-- <<Stencil::Block(custom)>> -->

<!-- <</Stencil::Block>> -->
