### PR TITLE
fix:  devspace handle multiple containers

### DIFF
--- a/templates/devspace.yaml.tpl
+++ b/templates/devspace.yaml.tpl
@@ -148,6 +148,7 @@ dev:
   # `dev.sync` configures a file sync between our Pods in k8s and your local project files
   sync:
     - name: app
+      containerName: ${DEVENV_DEPLOY_APPNAME}
       labelSelector: ${DEVENV_DEPLOY_LABELS}
       namespace: ${DEVENV_DEPLOY_NAMESPACE}
       localSubPath: ./
@@ -359,6 +360,7 @@ profiles:
             cd "${DEV_CONTAINER_WORKDIR}"
             "${DEV_CONTAINER_WORKDIR}/scripts/shell-wrapper.sh" devspace_start.sh
           container:
+            imageSelector: ${DEV_CONTAINER_IMAGE}
             labelSelector: ${DEVENV_DEPLOY_LABELS}
 
   - name: remoteAppImages


### PR DESCRIPTION
<!--
  !!!! README !!!! Please fill this out.

  Please follow the PR naming conventions: 
  https://outreach-io.atlassian.net/wiki/spaces/EN/pages/1902444645/Conventional+Commits
-->


<!-- A short description of what your PR does and what it solves. -->
## What this PR does / why we need it
Have devspace default to the container named after the service/app to handle multiple container pods. This should handle most use cases.


<!-- <<Stencil::Block(jiraPrefix)>> -->

## Jira ID

[DT-3136]

<!-- <</Stencil::Block>> -->

<!-- Notes that may be helpful for anyone reviewing this PR -->
## Notes for your reviewers



<!-- <<Stencil::Block(custom)>> -->

<!-- <</Stencil::Block>> -->


[DT-3136]: https://outreach-io.atlassian.net/browse/DT-3136?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ