### PR TITLE
feat: add ability to remove deployment replicas when using hpa

### DIFF
--- a/templates/.snapshots/TestRenderDeploymentJsonnet-deployments-appname-app.jsonnet.tpl-deployments-testing-testing.jsonnet.snapshot
+++ b/templates/.snapshots/TestRenderDeploymentJsonnet-deployments-appname-app.jsonnet.tpl-deployments-testing-testing.jsonnet.snapshot
@@ -236,9 +236,9 @@ ok.FilteredList() {
 	// Note: configuration overrides the <appName>.override.jsonnet file,
 	// which then overrides the objects found in this file.
 	// This is done via a simple key merge, and jsonnet object '+:' notation.
-	items_+:: all + (if isDev then developmentObjects else if app.clusterType == 'legacy' then {} else vaultOperatorSecrets)
+	items_+:: std.prune(all + (if isDev then developmentObjects else if app.clusterType == 'legacy' then {} else vaultOperatorSecrets)
 	+ mergedMixins
 	+ override
-	+ configuration
+	+ configuration)
 }
 )

--- a/templates/.snapshots/TestRenderDeploymentOverride-deployments-appname-app.override.jsonnet.tpl-deployments-testing-testing.override.jsonnet.snapshot
+++ b/templates/.snapshots/TestRenderDeploymentOverride-deployments-appname-app.override.jsonnet.tpl-deployments-testing-testing.override.jsonnet.snapshot
@@ -17,6 +17,8 @@ local isDev = (app.environment == 'development' || app.environment == 'local_dev
 
 // Objects contains kubernetes objects (or resources) that should be created in
 // all environments.
+// Note: If creating an HPA, you will need to remove the deployment.replica so it does not conflict.
+// Ex: deployment+: {spec+: { replicas: null, }, },
 local objects = {
 	// <<Stencil::Block(override)>>
 

--- a/templates/deployments/appname/app.jsonnet.tpl
+++ b/templates/deployments/appname/app.jsonnet.tpl
@@ -329,8 +329,8 @@ ok.FilteredList() {
 	// Note: configuration overrides the <appName>.override.jsonnet file,
 	// which then overrides the objects found in this file.
 	// This is done via a simple key merge, and jsonnet object '+:' notation.
-	items_+:: all + (if isDev then developmentObjects else if app.clusterType == 'legacy' then {} else vaultOperatorSecrets)
+	items_+:: std.prune(all + (if isDev then developmentObjects else if app.clusterType == 'legacy' then {} else vaultOperatorSecrets)
 	+ mergedMixins
 	+ override
-	+ configuration
+	+ configuration)
 }

--- a/templates/deployments/appname/app.override.jsonnet.tpl
+++ b/templates/deployments/appname/app.override.jsonnet.tpl
@@ -19,6 +19,8 @@ local isDev = (app.environment == 'development' || app.environment == 'local_dev
 
 // Objects contains kubernetes objects (or resources) that should be created in
 // all environments.
+// Note: If creating an HPA, you will need to remove the deployment.replica so it does not conflict.
+// Ex: deployment+: {spec+: { replicas: null, }, },
 local objects = {
 	// <<Stencil::Block(override)>>
 {{ file.Block "override" }}


### PR DESCRIPTION
<!--
  !!!! README !!!! Please fill this out.

  Please follow the PR naming conventions: 
  https://outreach-io.atlassian.net/wiki/spaces/EN/pages/1902444645/Conventional+Commits
-->


<!-- A short description of what your PR does and what it solves. -->
## What this PR does / why we need it
When using a horizontalPodAutoscaler (HPA) it's recommended to have that specify the replicas and not the deployment. Currently this isn't possible. This wraps the final jsonnet render in a `std.prune` to cull any null fields, and adds an example for how to remove the replicas field from a deployment when rolling out an HPA.

Docs: https://kubernetes.io/docs/tasks/run-application/horizontal-pod-autoscale/#migrating-deployments-and-statefulsets-to-horizontal-autoscaling


<!-- <<Stencil::Block(jiraPrefix)>> -->

## Jira ID

[DT-3458]

<!-- <</Stencil::Block>> -->

<!-- Notes that may be helpful for anyone reviewing this PR -->
## Notes for your reviewers



<!-- <<Stencil::Block(custom)>> -->

<!-- <</Stencil::Block>> -->


[DT-3458]: https://outreach-io.atlassian.net/browse/DT-3458?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ