### PR TITLE
feat: add pod-restart metrics for canary deployment

### DIFF
--- a/manifest.yaml
+++ b/manifest.yaml
@@ -192,6 +192,14 @@ arguments:
     schema:
       type: number
     description: Overrides the high traffic threshold in the "http_latency_high" terraform module in monitoring/datadog.tf.
+  terraform.datadog.podRestart.thresholds.lowCount:
+    schema:
+      type: number
+    description: Overrides the pod restarts threshold in the "pod_restarts" terraform module in monitoring/datadog.tf.
+  terraform.datadog.podRestart.thresholds.highCount:
+    schema:
+      type: number
+    description: Overrides the high pod restarts threshold in the "pod_restarts_high" terraform module in monitoring/datadog.tf.
   deployment.serviceDomains:
     description: The service domains that the service is deployed to.
     schema:

--- a/templates/.snapshots/TestDatadogTf_Override-monitoring-datadog.tf.tpl-monitoring-datadog.tf.snapshot
+++ b/templates/.snapshots/TestDatadogTf_Override-monitoring-datadog.tf.tpl-monitoring-datadog.tf.snapshot
@@ -24,13 +24,13 @@ variable cpu_high_window {
 
 variable pod_restart_low_count_threshold {
   type = number
-  default = 0
+  default = 7
 }
 
 # Number of restarts per 30m to be considered a P1 incident.
 variable pod_restart_high_count_threshold {
   type = number
-  default = 3
+  default = 11
 }
 
 variable "alert_on_panics" {

--- a/templates/.snapshots/TestRenderDeploymentJsonnet_Canary-deployments-appname-app.jsonnet.tpl-deployments-testing-testing.jsonnet.snapshot
+++ b/templates/.snapshots/TestRenderDeploymentJsonnet_Canary-deployments-appname-app.jsonnet.tpl-deployments-testing-testing.jsonnet.snapshot
@@ -18,6 +18,11 @@ local sharedLabels = {
 	reporting_team: 'test:team',
 };
 local deploymentMetrics = [
+  argo.AnalysisMetricDatadog('pod-restart') {
+		query:: 'default_zero(sum:kubernetes_state.container.restarts{kube_container_name:%(name)s,kube_namespace:%(namespace)s,role:canary})' % app,
+    successCondition: 'default(result, 0) <= 0',
+		interval: '1m',
+	},
 	argo.AnalysisMetricDatadog('http-error-rate') {
 		query:: 'moving_rollup(default_zero(100 * count:%(name)s.http_request_seconds{status:5xx,kube_namespace:%(namespace)s,image_tag:%(version)s}.as_count() / count:deploytestservice.http_request_seconds{kube_namespace:%(namespace)s,image_tag:%(version)s}.as_count()), 60, "max")' % app,
     successCondition: 'default(result, 0) < 10',

--- a/templates/.snapshots/TestRenderDeploymentJsonnet_Canary_emptyServiceActivities-deployments-appname-app.jsonnet.tpl-deployments-testing-testing.jsonnet.snapshot
+++ b/templates/.snapshots/TestRenderDeploymentJsonnet_Canary_emptyServiceActivities-deployments-appname-app.jsonnet.tpl-deployments-testing-testing.jsonnet.snapshot
@@ -18,6 +18,11 @@ local sharedLabels = {
 	reporting_team: 'test:team',
 };
 local deploymentMetrics = [
+  argo.AnalysisMetricDatadog('pod-restart') {
+		query:: 'default_zero(sum:kubernetes_state.container.restarts{kube_container_name:%(name)s,kube_namespace:%(namespace)s,role:canary})' % app,
+    successCondition: 'default(result, 0) <= 0',
+		interval: '1m',
+	},
 ];
 
 local all = {

--- a/templates/main_test.go
+++ b/templates/main_test.go
@@ -180,6 +180,33 @@ func TestDatadogTf(t *testing.T) {
 	st.Run(true)
 }
 
+func TestDatadogTf_Override(t *testing.T) {
+	st := stenciltest.New(t, "monitoring/datadog.tf.tpl", libaryTmpls...)
+	st.Args(map[string]interface{}{
+		"reportingTeam": "test:team",
+		"deployment": map[string]interface{}{
+			"environments": []interface{}{
+				"staging",
+				"production",
+			},
+			"serviceDomains": []interface{}{
+				"bento",
+			},
+		},
+		"terraform": map[string]interface{}{
+			"datadog": map[string]interface{}{
+				"podRestart": map[string]interface{}{
+					"thresholds": map[string]interface{}{
+						"lowCount":  7,
+						"highCount": 11,
+					},
+				},
+			},
+		},
+	})
+	st.Run(true)
+}
+
 func TestGRPCTf(t *testing.T) {
 	st := stenciltest.New(t, "monitoring/grpc.tf.tpl", libaryTmpls...)
 	st.Args(map[string]interface{}{

--- a/templates/monitoring/datadog.tf.tpl
+++ b/templates/monitoring/datadog.tf.tpl
@@ -23,10 +23,15 @@ variable cpu_high_window {
   default = 30
 }
 
-# Number of restarts per 30m to be considered a P1 incident.
-variable pod_restart_threshold {
+variable pod_restart_low_count_threshold {
   type = number
-  default = 3
+  default = {{ stencil.Arg "terraform.datadog.podRestart.thresholds.lowCount" | default 0 }}
+}
+
+# Number of restarts per 30m to be considered a P1 incident.
+variable pod_restart_high_count_threshold {
+  type = number
+  default = {{ stencil.Arg "terraform.datadog.podRestart.thresholds.highCount" | default 3 }}
 }
 
 variable "alert_on_panics" {
@@ -74,8 +79,8 @@ resource "datadog_monitor" "argocd_application_sync_status" {
 # splitting the interval 15 mins to 3 windows (moving rollup by 5mins) and if each of them contains restart -> alert
 resource "datadog_monitor" "pod_restarts" {
   type = "query alert"
-  name = "{{ .Config.Name | title }} Pod Restarts > 0 last 15m"
-  query = "min(last_15m):moving_rollup(diff(sum:kubernetes_state.container.restarts{kube_container_name:{{ .Config.Name }},!env:development} by {kube_namespace}), 300, 'sum') > 0"
+  name = "{{ .Config.Name | title }} Pod Restarts > ${var.pod_restart_low_count_threshold} last 15m"
+  query = "min(last_15m):moving_rollup(diff(sum:kubernetes_state.container.restarts{kube_container_name:{{ .Config.Name }},!env:development} by {kube_namespace}), 300, 'sum') > ${var.pod_restart_low_count_threshold}"
   tags = local.ddTags
   message = <<EOF
   If we ever have a pod restart, we want to know.
@@ -88,8 +93,8 @@ resource "datadog_monitor" "pod_restarts" {
 
 resource "datadog_monitor" "pod_restarts_high" {
   type = "query alert"
-  name = "{{ .Config.Name | title }} Pod Restarts > ${var.pod_restart_threshold} last 30m"
-  query = "max(last_30m):diff(sum:kubernetes_state.container.restarts{kube_container_name:{{ .Config.Name }},!env:development} by {kube_namespace}) > ${var.pod_restart_threshold}"
+  name = "{{ .Config.Name | title }} Pod Restarts > ${var.pod_restart_high_count_threshold} last 30m"
+  query = "max(last_30m):diff(sum:kubernetes_state.container.restarts{kube_container_name:{{ .Config.Name }},!env:development} by {kube_namespace}) > ${var.pod_restart_high_count_threshold}"
   tags = local.ddTags
   message = <<EOF
   Several pods are being restarted.


### PR DESCRIPTION
<!--
  !!!! README !!!! Please fill this out.

  Please follow the PR naming conventions: 
  https://outreach-io.atlassian.net/wiki/spaces/EN/pages/1902444645/Conventional+Commits
-->


<!-- A short description of what your PR does and what it solves. -->
## What this PR does / why we need it

- add override for pod-restart threshold for datadog terraform
- add pod-restart metric for Canary Deployment

[sample data](https://app.datadoghq.com/metric/explorer?start=1677536318490&end=1677539918490&paused=false#N4Ig7glgJg5gpgFxALlAGwIYE8D2BXJVEADxQEYAaELcqyKBAC1pEbghkcLIF8qo4AMwgA7CAgg4RKUAiwAHOChASAtnADOcAE4RNIKtrgBHPJoQaUAbVBGN8qVoD6gnNtUZCKiOq279VKY6epbINiAiGOrKQdpYZAYgUJ4YThr42gDGSsgg6gi6mZaBZnHKGniqyADWeABGOiKImmkInnAAdJlSbaI6HXZt2hbAtQ1O3SK9TdpOkerIAvJoOFgI5n4AbhDZFGNwc1Ga8hjZi3DLq+saFjrb2QC0DzcYMKIwAEx1PAAEdVg-YDaHBoOA8EA8AC6VFc7jwmFC4VhqnhGGUAkEGHhCCcAC8dDgABSxeIASgh0JANywoJkIBOoIQ63ROBgEwRGh2iTQfScckU5RB0G5vPoTGUIjcHjQEP4EHsmCwfIUORAPKaFJ4fCpy3EAGEpMIYCgRPC0DwgA)
![Screenshot 2023-02-27 at 3 18 37 PM](https://user-images.githubusercontent.com/93616024/221726519-1e9c954d-bd04-4322-9896-eaead50a2c58.png)


<!-- <<Stencil::Block(jiraPrefix)>> -->

## Jira ID

https://outreach-io.atlassian.net/browse/DT-3531

<!-- <</Stencil::Block>> -->

<!-- Notes that may be helpful for anyone reviewing this PR -->
## Notes for your reviewers



<!-- <<Stencil::Block(custom)>> -->

<!-- <</Stencil::Block>> -->
