### PR TITLE
fix: correct vscode debugger path mapping

### DIFF
--- a/templates/.vscode/launch.json.tpl
+++ b/templates/.vscode/launch.json.tpl
@@ -31,7 +31,11 @@
       "substitutePath": [
         {
           "from": "${workspaceRoot}",
-          "to": "/home/dev/app"
+          "to": "github.com/getoutreach/{{ .Config.Name }}"
+        },
+        {
+          "from": "${env:HOME}/.asdf/installs/golang/{{ stencil.ApplyTemplate "goVersion" }}/packages/pkg/mod",
+          "to": ""
         },
         {
           "from": "${env:HOME}/.asdf/installs/golang/{{ stencil.ApplyTemplate "goVersion" }}/packages/pkg/mod",


### PR DESCRIPTION
<!--
  !!!! README !!!! Please fill this out.

  Please follow the PR naming conventions: 
  https://outreach-io.atlassian.net/wiki/spaces/EN/pages/1902444645/Conventional+Commits
-->


<!-- A short description of what your PR does and what it solves. -->
## What this PR does / why we need it

After we added the build flag `trimpath`, instead of absolute file system paths, the recorded file names will begin either a module path@version (when using modules), or a plain import path (when using the standard library, or GOPATH).

We need to update `substitutePath` in vscode debug settings so that the debugger can find the proper code path.

<!-- <<Stencil::Block(jiraPrefix)>> -->

## Jira ID

[XX-XX]

<!-- <</Stencil::Block>> -->

<!-- Notes that may be helpful for anyone reviewing this PR -->
## Notes for your reviewers



<!-- <<Stencil::Block(custom)>> -->

<!-- <</Stencil::Block>> -->
