### PR TITLE
fix(DT-3543): Cleaning up out-of-the-box imports

### DIFF
--- a/templates/cmd/main.go.tpl
+++ b/templates/cmd/main.go.tpl
@@ -11,22 +11,29 @@ package main
 
 import (
 	"context"
-	"fmt"
 	"os"
 
-	"golang.org/x/sync/errgroup"
-	"go.uber.org/automaxprocs/maxprocs"
-
 	"github.com/getoutreach/gobox/pkg/app"
+	"github.com/getoutreach/gobox/pkg/async"
 	"github.com/getoutreach/gobox/pkg/env"
 	"github.com/getoutreach/gobox/pkg/log"
 	"github.com/getoutreach/gobox/pkg/events"
 	"github.com/getoutreach/gobox/pkg/trace"
-	"github.com/getoutreach/tollmon/pkg/tollgate"
 	"github.com/getoutreach/stencil-golang/pkg/serviceactivities/shutdown"
 	"github.com/getoutreach/stencil-golang/pkg/serviceactivities/gomaxprocs"
+	"github.com/pkg/errors"
 
 	"{{ stencil.ApplyTemplate "appImportPath" }}/internal/{{ .Config.Name }}"
+
+	{{- $additionalImports := stencil.GetModuleHook "main/additionalImports" }}
+	{{- if $additionalImports }}
+
+	// Code inserted by modules
+		{{- range $additionalImports  }}
+	{{ . | quote }}
+		{{- end }}
+	// End code inserted by modules
+	{{- end }}
 
 	// Place any extra imports for your startup code here
 	// <<Stencil::Block(imports)>>

--- a/templates/internal/appName/config.go.tpl
+++ b/templates/internal/appName/config.go.tpl
@@ -10,13 +10,12 @@ package {{ stencil.ApplyTemplate "goPackageSafeName" }} //nolint:revive // Why: 
 
 import (
 	"context"
-	"os"
-	"strings"
 
 	"github.com/getoutreach/gobox/pkg/cfg"
 	"github.com/getoutreach/gobox/pkg/log"
-	"github.com/getoutreach/gobox/pkg/events"
+	{{- if has "kafka" (stencil.Arg "serviceActivities") }}
 	"github.com/getoutreach/services/pkg/find"
+  {{- end }}
 	// <<Stencil::Block(configImports)>>
 {{ file.Block "configImports" }}
 	// <</Stencil::Block>>

--- a/templates/internal/appName/http/httpservice.go.tpl
+++ b/templates/internal/appName/http/httpservice.go.tpl
@@ -14,8 +14,6 @@ import (
 	"fmt"
 	"net/http"
 
-	"github.com/getoutreach/gobox/pkg/events"
-	"github.com/getoutreach/gobox/pkg/log"
 	"github.com/getoutreach/httpx/pkg/handlers"
 
   {{- $additionalImports := stencil.GetModuleHook "internal/http/additionalImports" }}

--- a/templates/internal/appName/rpc/rpc.go.tpl
+++ b/templates/internal/appName/rpc/rpc.go.tpl
@@ -17,7 +17,6 @@ import (
 	"fmt"
 	"net"
 
-	"github.com/getoutreach/gobox/pkg/app"
 	"github.com/getoutreach/gobox/pkg/events"
 	"github.com/getoutreach/gobox/pkg/log"
 	"github.com/getoutreach/gobox/pkg/trace"

--- a/templates/internal/appName/rpc/server.go.tpl
+++ b/templates/internal/appName/rpc/server.go.tpl
@@ -13,6 +13,7 @@ package {{ stencil.ApplyTemplate "goPackageSafeName" }} //nolint:revive // Why: 
 
 import (
 	"context"
+  "fmt"
 )
 
 // Server is the actual server implementation of the API.


### PR DESCRIPTION
Also had to add a new imports module hook to handle stuff from:
https://github.com/getoutreach/stencil-outreach/pull/113/files