### PR TITLE
fix: CRDv1 incorrect syntax

### DIFF
--- a/templates/deployments/appname/mixins/kubernetes.jsonnet.tpl
+++ b/templates/deployments/appname/mixins/kubernetes.jsonnet.tpl
@@ -169,7 +169,7 @@ local controllers = {
   {{- range $r := $g.resources }}
   {{- $snakeKind := $r.kind | lower | snakecase }}
   {{- if $r.generate.controller }}
-  {{ $snakeKind }} : ok.CRDv1('{{ $r.kind }}', '{{ $g.group }}', '{{ $g.version }}') {
+  {{ $snakeKind }} : ok.CRDv1('{{ $r.kind }}', '{{ $g.group }}', 'apiextensions.k8s.io/v1', ['{{ $g.version }}']) {
     metadata+: {
       labels+: {
         reporting_team: team,


### PR DESCRIPTION
Fixing broken jsonnet-libs call after https://github.com/getoutreach/stencil-golang/commit/e9825c36865ddd7c75eba083e63bc34a2c58a91a