### PR TITLE
fix: update panic monitor

### DIFF
--- a/templates/.snapshots/TestDatadogTf-monitoring-datadog.tf.tpl-monitoring-datadog.tf.snapshot
+++ b/templates/.snapshots/TestDatadogTf-monitoring-datadog.tf.tpl-monitoring-datadog.tf.snapshot
@@ -141,7 +141,7 @@ resource "datadog_monitor" "pod_memory_working_set_high" {
 resource "datadog_monitor" "panics" {
   type    = "log alert"
   name    = "Testing Service panics"
-  query   = "logs(\"panic status:error service:testing -env:development\").index(\"*\").rollup(\"count\").by(\"kube_namespace\").last(\"5m\") > 0"
+  query   = "logs(\"panic status:error service:testing--* -env:development\").index(\"*\").rollup(\"count\").by(\"kube_namespace,service\").last(\"5m\") > 0"
   tags    = local.ddTags
   message = <<EOF
   Log based monitor of runtime error panics.

--- a/templates/.snapshots/TestDatadogTf_Override-monitoring-datadog.tf.tpl-monitoring-datadog.tf.snapshot
+++ b/templates/.snapshots/TestDatadogTf_Override-monitoring-datadog.tf.tpl-monitoring-datadog.tf.snapshot
@@ -141,7 +141,7 @@ resource "datadog_monitor" "pod_memory_working_set_high" {
 resource "datadog_monitor" "panics" {
   type    = "log alert"
   name    = "Testing Service panics"
-  query   = "logs(\"panic status:error service:testing -env:development\").index(\"*\").rollup(\"count\").by(\"kube_namespace\").last(\"5m\") > 0"
+  query   = "logs(\"panic status:error service:testing--* -env:development\").index(\"*\").rollup(\"count\").by(\"kube_namespace,service\").last(\"5m\") > 0"
   tags    = local.ddTags
   message = <<EOF
   Log based monitor of runtime error panics.

--- a/templates/monitoring/datadog.tf.tpl
+++ b/templates/monitoring/datadog.tf.tpl
@@ -148,7 +148,7 @@ resource "datadog_monitor" "pod_memory_working_set_high" {
 resource "datadog_monitor" "panics" {
   type    = "log alert"
   name    = "{{ .Config.Name | title }} Service panics"
-  query   = "logs(\"panic status:error service:{{ .Config.Name }} -env:development\").index(\"*\").rollup(\"count\").by(\"kube_namespace\").last(\"5m\") > 0"
+  query   = "logs(\"panic status:error kube_namespace:{{ .Config.Name }}--* -env:development\").index(\"*\").rollup(\"count\").by(\"kube_namespace,service\").last(\"5m\") > 0"
   tags    = local.ddTags
   message = <<EOF
   Log based monitor of runtime error panics.


### PR DESCRIPTION


<!--
  !!!! README !!!! Please fill this out.

  Please follow the PR naming conventions: 
  https://outreach-io.atlassian.net/wiki/spaces/EN/pages/1902444645/Conventional+Commits
-->


<!-- A short description of what your PR does and what it solves. -->
## What this PR does / why we need it
Update the panic monitor to include all pods in the service namespace. Previously, we only included the service pod. This caused us to miss some panics in ingestion pods.


<!-- <<Stencil::Block(jiraPrefix)>> -->

## Jira ID

[VXP-5941]

<!-- <</Stencil::Block>> -->

<!-- Notes that may be helpful for anyone reviewing this PR -->
## Notes for your reviewers
- [ ] I re-stenciled the callstatemanager service with this change and verified that the monitor behaves as expected.


<!-- <<Stencil::Block(custom)>> -->

<!-- <</Stencil::Block>> -->
