### PR TITLE
feat: support unmanaged CLIs

### DIFF
--- a/manifest.yaml
+++ b/manifest.yaml
@@ -42,7 +42,13 @@ arguments:
     schema:
       type: array
       items:
-        type: string
+        anyOf:
+          - type: string
+          - type: object
+            properties:
+              unmanaged:
+                type: boolean
+                description: If true, stencil will not generate an entrypoint go file for this CLI (`cmd/<name>/<name>.go`), but still will build and distribute it.
     description: List of CLI commands to generate for this repository
   grpcClients:
     schema:

--- a/templates/.goreleaser.yml.tpl
+++ b/templates/.goreleaser.yml.tpl
@@ -1,7 +1,7 @@
 {{- if not (stencil.Arg "commands") }}
 {{ file.Skip "No commands defined" }}
 {{- end }}
-# Documentation for this file: http://goreleaser.com
+# yaml-language-server: $schema=https://goreleaser.com/static/schema.json
 before:
   hooks:
     - make dep

--- a/templates/.goreleaser.yml.tpl
+++ b/templates/.goreleaser.yml.tpl
@@ -7,6 +7,9 @@ before:
     - make dep
 builds:
 {{- range $cmdName := stencil.Arg "commands" }}
+{{- if kindIs "map" $cmdName }}
+{{- $cmdName = (index (keys $cmdName) 0) }}
+{{- end }}
 - main: ./cmd/{{ $cmdName }}
   id: &name {{ $cmdName }}
   binary: *name
@@ -23,6 +26,7 @@ builds:
   env:
   - CGO_ENABLED=0
 {{- end }}
+
 archives: []
 checksum:
   name_template: 'checksums.txt'

--- a/templates/.snapshots/TestBasicGoMod-go.mod.tpl-go.mod.snapshot
+++ b/templates/.snapshots/TestBasicGoMod-go.mod.tpl-go.mod.snapshot
@@ -3,5 +3,5 @@
 go 1.19
 
 require (
-	github.com/getoutreach/gobox v1.65.1
+	github.com/getoutreach/gobox v1.66.0
 ))

--- a/templates/.snapshots/TestGoModStanzaVersion-go.mod.tpl-go.mod.snapshot
+++ b/templates/.snapshots/TestGoModStanzaVersion-go.mod.tpl-go.mod.snapshot
@@ -3,5 +3,5 @@
 go 1.19
 
 require (
-	github.com/getoutreach/gobox v1.65.1
+	github.com/getoutreach/gobox v1.66.0
 ))

--- a/templates/.snapshots/TestMergeGoMod-go.mod.tpl-go.mod.snapshot
+++ b/templates/.snapshots/TestMergeGoMod-go.mod.tpl-go.mod.snapshot
@@ -6,7 +6,7 @@ go 1.19
 
 require (
 	github.com/blang/semver/v4 v4.0.0
-	github.com/getoutreach/gobox v1.65.1
+	github.com/getoutreach/gobox v1.66.0
 	github.com/getoutreach/stencil v1.28.0-rc.2
 	github.com/pkg/errors v0.9.1
 	github.com/sirupsen/logrus v1.9.0

--- a/templates/_helpers.tpl
+++ b/templates/_helpers.tpl
@@ -95,7 +95,7 @@
 {{- define "dependencies" }}
 go:
 - name: github.com/getoutreach/gobox
-  version: v1.65.1
+  version: v1.66.0
 
 {{- if has "grpc" (stencil.Arg "serviceActivities") }}
 - name: google.golang.org/grpc


### PR DESCRIPTION
<!--
  !!!! README !!!! Please fill this out.

  Please follow the PR naming conventions: 
  https://outreach-io.atlassian.net/wiki/spaces/EN/pages/1902444645/Conventional+Commits
-->


<!-- A short description of what your PR does and what it solves. -->
## What this PR does / why we need it

This PR adds support for unmanaged CLIs, useful for when you want to use the stencil CLI distribution framework but not opt into the CLI framework (e.g., no updater, or other aspects of it).

This is done by overloading the `commands` argument to support the original:

```yaml
commands:
- a-cool-command
```

but also a new format:

```yaml
commands:
- a-cool-command:
    option: true
```

To opt-out, one can now set `unmanaged`:

```yaml
commands:
- a-cool-command:
    unmanaged: true
```

This unmanaged the CLI file by setting it to 'static' and generating only a minimal `main.go` placeholder. Goreleaser, semantic-release, and etc are still used to package and distribute the binary as normal.

<!-- <<Stencil::Block(jiraPrefix)>> -->

## Jira ID

[XX-XX]

<!-- <</Stencil::Block>> -->

<!-- Notes that may be helpful for anyone reviewing this PR -->
## Notes for your reviewers



<!-- <<Stencil::Block(custom)>> -->

<!-- <</Stencil::Block>> -->
