### PR TITLE
feat(cli): support delibird integration

### DIFF
--- a/manifest.yaml
+++ b/manifest.yaml
@@ -46,6 +46,11 @@ arguments:
           - type: string
           - type: object
             properties:
+              delibird:
+                type: boolean
+                description: |-
+                  Opt into using using local files for tracing/session recording for usage with Delibird. This is used to prevent telemetry from leaving a user's
+                  machine, without an accompanying daemon component running that uploads them to delibird. The primary usecase is for being OSS friendly.
               unmanaged:
                 type: boolean
                 description: If true, stencil will not generate an entrypoint go file for this CLI (`cmd/<name>/<name>.go`), but still will build and distribute it.

--- a/templates/.goreleaser.yml.tpl
+++ b/templates/.goreleaser.yml.tpl
@@ -7,8 +7,10 @@ before:
     - make dep
 builds:
 {{- range $cmdName := stencil.Arg "commands" }}
+{{- $opts := (dict) }}
 {{- if kindIs "map" $cmdName }}
 {{- $cmdName = (index (keys $cmdName) 0) }}
+{{- $opts = (index . $cmdName | default (dict)) }}
 {{- end }}
 - main: ./cmd/{{ $cmdName }}
   id: &name {{ $cmdName }}
@@ -21,8 +23,10 @@ builds:
   - arm64
   ldflags:
    - '-w -s -X "github.com/getoutreach/gobox/pkg/app.Version=v{{ "{{" }} .Version {{ "}}" }}"'
+   {{- if not $opts.delibird }}
    - '-X "main.HoneycombTracingKey={{ "{{" }} .Env.HONEYCOMB_APIKEY {{ "}}" }}"'
    - '-X "main.TeleforkAPIKey={{ "{{" }} .Env.TELEFORK_APIKEY {{ "}}" }}"'
+   {{- end }}
   env:
   - CGO_ENABLED=0
 {{- end }}


### PR DESCRIPTION
<!--
  !!!! README !!!! Please fill this out.

  Please follow the PR naming conventions: 
  https://outreach-io.atlassian.net/wiki/spaces/EN/pages/1902444645/Conventional+Commits
-->


<!-- A short description of what your PR does and what it solves. -->
## What this PR does / why we need it

This PR adds support for the delibird logfile system to CLIs, opt-in-able with `delibird: true` on the command object. Example:

```yaml
commands:
- stencil:
    delibird: true 
```

<!-- <<Stencil::Block(jiraPrefix)>> -->

## Jira ID

[XX-XX]

<!-- <</Stencil::Block>> -->

<!-- Notes that may be helpful for anyone reviewing this PR -->
## Notes for your reviewers



<!-- <<Stencil::Block(custom)>> -->

<!-- <</Stencil::Block>> -->
