### PR TITLE
fix(release): use stencil-outreach for opslevel

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -8,6 +8,10 @@ updates:
     # stencil-golang managed dependencies
     ignore:
       - dependency-name: github.com/getoutreach/gobox
+      - dependency-name: github.com/getoutreach/datastores/v2
+      - dependency-name: github.com/getoutreach/mint
+      - dependency-name: github.com/getoutreach/httpx
+      - dependency-name: github.com/getoutreach/services
       - dependency-name: github.com/getoutreach/stencil
 
   # Ignore semantic-release, this code is only executed in CI.

--- a/.vscode/outreach.code-snippets
+++ b/.vscode/outreach.code-snippets
@@ -1,0 +1,29 @@
+{
+	"Outreach E2E Test Build Tags": {
+		"scope": "go",
+		"prefix": "build-tag-e2e",
+		"body": [
+			"//go:build or_e2e",
+			"// +build or_e2e\n\n"
+		],
+		"description": "Build tags for end-to-end test files"
+	},
+	"Outreach Unit Test Build Tags": {
+		"scope": "go",
+		"prefix": "build-tag-unit",
+		"body": [
+			"//go:build or_test",
+			"// +build or_test\n\n"
+		],
+		"description": "Build tags for unit test files"
+	},
+	"Outreach Copyright and Description": {
+		"scope": "go",
+		"prefix": "copyright",
+		"body": [
+			"// Copyright ${CURRENT_YEAR} Outreach Corporation. All Rights Reserved.\n",
+			"// Description: $0"
+		],
+		"description": "Outreach Copyright and Description"
+	}
+}

--- a/.vscode/private.env
+++ b/.vscode/private.env
@@ -1,4 +1,6 @@
 MY_NAMESPACE="stencil-golang--bento1a"
+OUTREACH_DOMAIN="outreach-dev.com"
+OUTREACH_ACCOUNTS_BASE_URL="https://accounts.outreach-dev.com"
 // <<Stencil::Block(vscodeEnvVars)>>
 
 // <</Stencil::Block>>

--- a/opslevel.yml
+++ b/opslevel.yml
@@ -1,0 +1,54 @@
+# yaml-language-server: $schema=https://app.opslevel.com/public/opslevel.schema.yml
+
+# Available options are listed here: https://app.opslevel.com/account
+# To find the alias for a given lifecycle: https://www.opslevel.com/docs/api/opslevel-yml/#finding-the-alias-for-a-lifecycle
+# To find the alias for a given tier: https://www.opslevel.com/docs/api/opslevel-yml/#finding-the-alias-for-a-tier
+# More examples: https://opslevel.com/docs/api/opslevel-yml/#example-service-opslevelyml
+
+version: 1
+service:
+  name: stencil-golang
+  product: Outreach
+  owner: fnd-dt
+  language: Golang
+  framework: stencil
+  description: >
+    Stencil Module for Golang Applications
+  lifecycle: in_development
+  ## <<Stencil::Block(extraServiceMetadata)>>
+
+  ## <</Stencil::Block>>
+  aliases:
+    ## <<Stencil::Block(extraAliases)>>
+
+    ## <</Stencil::Block>>
+    - stencil-golang
+  tags:
+    ## <<Stencil::Block(extraTags)>>
+
+    ## <</Stencil::Block>>
+    - key: repo
+      value: "https://github.com/getoutreach/stencil-golang"
+    - key: reporting_team
+      value: "fnd-dt"
+    - key: app
+      value: "stencil-golang"
+    - key: name
+      value: "stencil-golang"
+    - key: stencil_version
+      value: "v1.32.0"
+    - key: golang_version
+      value: "1.19.5"
+    - key: cli
+      value: "false"
+    - key: service
+      value: "false"
+      # This is necessary for filters in OpsLevel because we have to assume all things are
+      # services if they don't have the `service` tag. So we can guarantee this tag for
+      # bootstrapped CLIs/Libraries.
+    - key: notservice
+      value: "true"
+  repositories:
+    - name: getoutreach/stencil-golang
+      path: "/"
+      provider: github

--- a/service.yaml
+++ b/service.yaml
@@ -12,6 +12,7 @@ arguments:
     prereleasesBranch: rc
 modules:
   - name: github.com/getoutreach/stencil-template-base
+  - name: github.com/getoutreach/stencil-outreach # Required for opslevel.yml
   - name: github.com/getoutreach/stencil-circleci
   - name: github.com/getoutreach/stencil-base
   - name: github.com/getoutreach/devbase

--- a/stencil.lock
+++ b/stencil.lock
@@ -9,9 +9,18 @@ modules:
     - name: github.com/getoutreach/stencil-circleci
       url: https://github.com/getoutreach/stencil-circleci
       version: v1.7.0
+    - name: github.com/getoutreach/stencil-discovery
+      url: https://github.com/getoutreach/stencil-discovery
+      version: v1.4.1
     - name: github.com/getoutreach/stencil-golang
       url: https://github.com/getoutreach/stencil-golang
       version: v1.8.0
+    - name: github.com/getoutreach/stencil-outreach
+      url: https://github.com/getoutreach/stencil-outreach
+      version: v0.8.0
+    - name: github.com/getoutreach/stencil-pipeline
+      url: https://github.com/getoutreach/stencil-pipeline
+      version: v1.1.0
     - name: github.com/getoutreach/stencil-template-base
       url: https://github.com/getoutreach/stencil-template-base
       version: v0.5.0
@@ -58,6 +67,9 @@ files:
     - name: .vscode/launch.json
       template: .vscode/launch.json.tpl
       module: github.com/getoutreach/stencil-golang
+    - name: .vscode/outreach.code-snippets
+      template: .vscode/outreach.code-snippets.tpl
+      module: github.com/getoutreach/stencil-outreach
     - name: .vscode/private.env
       template: .vscode/private.env.tpl
       module: github.com/getoutreach/stencil-golang
@@ -82,6 +94,9 @@ files:
     - name: manifest.yaml
       template: manifest.yaml.tpl
       module: github.com/getoutreach/stencil-template-base
+    - name: opslevel.yml
+      template: opslevel.yml.tpl
+      module: github.com/getoutreach/stencil-outreach
     - name: package.json
       template: package.json.tpl
       module: github.com/getoutreach/stencil-base


### PR DESCRIPTION
<!--
  !!!! README !!!! Please fill this out.

  Please follow the PR naming conventions: 
  https://outreach-io.atlassian.net/wiki/spaces/EN/pages/1902444645/Conventional+Commits
-->


<!-- A short description of what your PR does and what it solves. -->
## What this PR does / why we need it

This PR adds a dependency on `stencil-outreach` so that we're able to release w/ `opslevel`

<!-- <<Stencil::Block(jiraPrefix)>> -->

## Jira ID

[XX-XX]

<!-- <</Stencil::Block>> -->

<!-- Notes that may be helpful for anyone reviewing this PR -->
## Notes for your reviewers



<!-- <<Stencil::Block(custom)>> -->

<!-- <</Stencil::Block>> -->
