### PR TITLE
fix: upgrade gobox for new github CLI auth format support

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -6,7 +6,7 @@ go 1.19
 
 require (
 	github.com/blang/semver/v4 v4.0.0
-	github.com/getoutreach/gobox v1.67.1
+	github.com/getoutreach/gobox v1.68.1
 	github.com/getoutreach/stencil v1.32.0
 	github.com/magefile/mage v1.14.0
 	github.com/pkg/errors v0.9.1

--- a/go.sum
+++ b/go.sum
@@ -44,8 +44,8 @@ github.com/fatih/color v1.13.0/go.mod h1:kLAiJbzzSOZDVNGyDpeOxJ47H46qBXwg5ILebYF
 github.com/fatih/color v1.14.1 h1:qfhVLaG5s+nCROl1zJsZRxFeYrHLqWroPOQ8BWiNb4w=
 github.com/fatih/color v1.14.1/go.mod h1:2oHN61fhTpgcxD3TSWCgKDiH1+x4OiDVVGH8WlgGZGg=
 github.com/frankban/quicktest v1.14.3 h1:FJKSZTDHjyhriyC81FLQ0LY93eSai0ZyR/ZIkd3ZUKE=
-github.com/getoutreach/gobox v1.67.1 h1:jNONUQ3Cod3QlVEuzryDnlMDwisk6sOqjIU0IsBXxHE=
-github.com/getoutreach/gobox v1.67.1/go.mod h1:D4CJbOmGrdAAFxgY/3sFVwgag3639Nd0fOFrkdBoU8s=
+github.com/getoutreach/gobox v1.68.1 h1:rYsfEvgBqIXlL7/MovlqTXOWGw3q7qwz9j5rh6PE8CM=
+github.com/getoutreach/gobox v1.68.1/go.mod h1:OUNenxrlCtCy3aWyRfWz78lcXQZU2gvTHWrMjyGS2eU=
 github.com/getoutreach/stencil v1.32.0 h1:Y96AEiPIEnAnq+D9Pw5dscRx1uGHIvBxanddv/ZXHH4=
 github.com/getoutreach/stencil v1.32.0/go.mod h1:LOqU8NMErrkZCnVX8+EPKkZHGSg3dvBqA9wPXmhJ8wM=
 github.com/gliderlabs/ssh v0.3.5 h1:OcaySEmAQJgyYcArR+gGGTHCyE7nvhEMTlYY+Dp8CpY=

--- a/templates/.snapshots/TestBasicGoMod-go.mod.tpl-go.mod.snapshot
+++ b/templates/.snapshots/TestBasicGoMod-go.mod.tpl-go.mod.snapshot
@@ -3,5 +3,5 @@
 go 1.19
 
 require (
-	github.com/getoutreach/gobox v1.68.0
+	github.com/getoutreach/gobox v1.68.1
 ))

--- a/templates/.snapshots/TestGoModStanzaVersion-go.mod.tpl-go.mod.snapshot
+++ b/templates/.snapshots/TestGoModStanzaVersion-go.mod.tpl-go.mod.snapshot
@@ -3,5 +3,5 @@
 go 1.19
 
 require (
-	github.com/getoutreach/gobox v1.68.0
+	github.com/getoutreach/gobox v1.68.1
 ))

--- a/templates/.snapshots/TestMergeGoMod-go.mod.tpl-go.mod.snapshot
+++ b/templates/.snapshots/TestMergeGoMod-go.mod.tpl-go.mod.snapshot
@@ -6,7 +6,7 @@ go 1.19
 
 require (
 	github.com/blang/semver/v4 v4.0.0
-	github.com/getoutreach/gobox v1.68.0
+	github.com/getoutreach/gobox v1.68.1
 	github.com/getoutreach/stencil v1.28.0-rc.2
 	github.com/pkg/errors v0.9.1
 	github.com/sirupsen/logrus v1.9.0

--- a/templates/_helpers.tpl
+++ b/templates/_helpers.tpl
@@ -101,7 +101,7 @@
 {{- define "dependencies" }}
 go:
 - name: github.com/getoutreach/gobox
-  version: v1.68.0
+  version: v1.68.1
 
 {{- if has "grpc" (stencil.Arg "serviceActivities") }}
 - name: google.golang.org/grpc


### PR DESCRIPTION
<!--
  !!!! README !!!! Please fill this out.

  Please follow the PR naming conventions: 
  https://outreach-io.atlassian.net/wiki/spaces/EN/pages/1902444645/Conventional+Commits
-->


<!-- A short description of what your PR does and what it solves. -->
## What this PR does / why we need it

Upgrades the version of gobox in use to enable the new `gh` CLI keyring storage added in https://github.com/getoutreach/gobox/pull/298

<!-- <<Stencil::Block(jiraPrefix)>> -->

## Jira ID

[DT-3656]

<!-- <</Stencil::Block>> -->

<!-- Notes that may be helpful for anyone reviewing this PR -->
## Notes for your reviewers



<!-- <<Stencil::Block(custom)>> -->

<!-- <</Stencil::Block>> -->


[DT-3656]: https://outreach-io.atlassian.net/browse/DT-3656?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ