### PR TITLE
fix(golang): use 1.19.8 due to golangci-lint incompat

### DIFF
--- a/manifest.yaml
+++ b/manifest.yaml
@@ -230,7 +230,7 @@ arguments:
     default: ""
   versions.go:
     description: Go version to use
-    default: "1.20.3"
+    default: "1.19.8"
     schema:
       type:
         - string

--- a/templates/.snapshots/TestRenderDeploymentDockerfile-deployments-appname-Dockerfile.tpl-deployments-testing-Dockerfile.snapshot
+++ b/templates/.snapshots/TestRenderDeploymentDockerfile-deployments-appname-Dockerfile.tpl-deployments-testing-Dockerfile.snapshot
@@ -1,5 +1,5 @@
 (*codegen.File)(# syntax=docker/dockerfile:1.0-experimental
-FROM gcr.io/outreach-docker/golang:1.20.3 as builder
+FROM gcr.io/outreach-docker/golang:1.19.8 as builder
 ARG VERSION
 ENV GOCACHE "/go-build-cache"
 ENV GOPRIVATE github.com/getoutreach/*


### PR DESCRIPTION
<!--
  !!!! README !!!! Please fill this out.

  Please follow the PR naming conventions: 
  https://outreach-io.atlassian.net/wiki/spaces/EN/pages/1902444645/Conventional+Commits
-->


<!-- A short description of what your PR does and what it solves. -->
## What this PR does / why we need it

This PR changes the version of Go back to 1.19 (but upgrades to the latest patch) due to incompat with the golangci-lint version we're stuck on (see https://github.com/getoutreach/devbase/pull/507). It hangs, forever, for no reason and consumes all the CPU. Amazing.

<!-- <<Stencil::Block(jiraPrefix)>> -->

## Jira ID

[XX-XX]

<!-- <</Stencil::Block>> -->

<!-- Notes that may be helpful for anyone reviewing this PR -->
## Notes for your reviewers

Requires https://github.com/getoutreach/outreach-docker/pull/580

<!-- <<Stencil::Block(custom)>> -->

<!-- <</Stencil::Block>> -->
