### PR TITLE
fix(devspace): support new gh keychain backend

### DIFF
--- a/templates/devspace.yaml.tpl
+++ b/templates/devspace.yaml.tpl
@@ -76,7 +76,7 @@ vars:
 
   - name: GH_TOKEN
     source: command
-    command: yq -r '.["github.com"].oauth_token' "$HOME/.config/gh/hosts.yml"
+    command: gh auth token
   - name: NPM_TOKEN
     source: command
     command: grep -E "registry.npmjs.org(.+)_authToken=(.+)" $HOME/.npmrc | sed 's/.*=//g'


### PR DESCRIPTION
<!--
  !!!! README !!!! Please fill this out.

  Please follow the PR naming conventions: 
  https://outreach-io.atlassian.net/wiki/spaces/EN/pages/1902444645/Conventional+Commits
-->


<!-- A short description of what your PR does and what it solves. -->
## What this PR does / why we need it

Moves from reading from the `yaml` file to the new `gh auth token`, related to https://github.com/getoutreach/gobox/pull/298.


<!-- <<Stencil::Block(jiraPrefix)>> -->

## Jira ID

[DT-3656]

<!-- <</Stencil::Block>> -->

<!-- Notes that may be helpful for anyone reviewing this PR -->
## Notes for your reviewers



<!-- <<Stencil::Block(custom)>> -->

<!-- <</Stencil::Block>> -->


[DT-3656]: https://outreach-io.atlassian.net/browse/DT-3656?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ