### PR TITLE
fix(devspace): proper gh auth token support

### DIFF
--- a/templates/devspace.yaml.tpl
+++ b/templates/devspace.yaml.tpl
@@ -76,7 +76,12 @@ vars:
 
   - name: GH_TOKEN
     source: command
-    command: gh auth token
+    # GH_TOKEN is set to null when running the provided command. This conflicts
+    # with the 'gh auth token' logic which will always use the env var over the
+    # keyring or config file. To handle this, we unset GH_TOKEN only when it is
+    # set to "null". This enables us to ignore it when it's not set but still
+    # allow GH_TOKEN to be set and supported (as 'gh auth token' does support it)
+    command: '[[ "$GH_TOKEN" == "null" ]] && unset GH_TOKEN; gh auth token'
   - name: NPM_TOKEN
     source: command
     command: grep -E "registry.npmjs.org(.+)_authToken=(.+)" $HOME/.npmrc | sed 's/.*=//g'


### PR DESCRIPTION
<!--
  !!!! README !!!! Please fill this out.

  Please follow the PR naming conventions: 
  https://outreach-io.atlassian.net/wiki/spaces/EN/pages/1902444645/Conventional+Commits
-->


<!-- A short description of what your PR does and what it solves. -->
## What this PR does / why we need it

This PR adjusts the `GH_TOKEN` command for `devspace` to actually... work :D. See comment on the variable for an explanation on why we're doing this hackiness.

<!-- <<Stencil::Block(jiraPrefix)>> -->

## Jira ID

[DT-3670]

<!-- <</Stencil::Block>> -->

<!-- Notes that may be helpful for anyone reviewing this PR -->
## Notes for your reviewers



<!-- <<Stencil::Block(custom)>> -->

<!-- <</Stencil::Block>> -->


[DT-3670]: https://outreach-io.atlassian.net/browse/DT-3670?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ