### PR TITLE
fix(trace): lower non dev samplepercent to 0.25 (1 in 400)

### DIFF
--- a/templates/.snapshots/TestRenderDeploymentJsonnet-deployments-appname-app.jsonnet.tpl-deployments-testing-testing.jsonnet.snapshot
+++ b/templates/.snapshots/TestRenderDeploymentJsonnet-deployments-appname-app.jsonnet.tpl-deployments-testing-testing.jsonnet.snapshot
@@ -79,7 +79,7 @@ local all = {
 					Path: '/run/secrets/outreach.io/honeycomb/apiKey',
 				},
 				Dataset: if isDev then 'dev' else 'outreach',
-				SamplePercent: if isDev then 100 else 1,
+				SamplePercent: if isDev then 100 else 0.25,
 			},
 		} + if isDev then {
 			GlobalTags+: {

--- a/templates/.snapshots/TestRenderDeploymentJsonnet_Canary-deployments-appname-app.jsonnet.tpl-deployments-testing-testing.jsonnet.snapshot
+++ b/templates/.snapshots/TestRenderDeploymentJsonnet_Canary-deployments-appname-app.jsonnet.tpl-deployments-testing-testing.jsonnet.snapshot
@@ -114,7 +114,7 @@ local all = {
 					Path: '/run/secrets/outreach.io/honeycomb/apiKey',
 				},
 				Dataset: if isDev then 'dev' else 'outreach',
-				SamplePercent: if isDev then 100 else 1,
+				SamplePercent: if isDev then 100 else 0.25,
 			},
 		} + if isDev then {
 			GlobalTags+: {

--- a/templates/.snapshots/TestRenderDeploymentJsonnet_Canary_emptyServiceActivities-deployments-appname-app.jsonnet.tpl-deployments-testing-testing.jsonnet.snapshot
+++ b/templates/.snapshots/TestRenderDeploymentJsonnet_Canary_emptyServiceActivities-deployments-appname-app.jsonnet.tpl-deployments-testing-testing.jsonnet.snapshot
@@ -86,7 +86,7 @@ local all = {
 					Path: '/run/secrets/outreach.io/honeycomb/apiKey',
 				},
 				Dataset: if isDev then 'dev' else 'outreach',
-				SamplePercent: if isDev then 100 else 1,
+				SamplePercent: if isDev then 100 else 0.25,
 			},
 		} + if isDev then {
 			GlobalTags+: {

--- a/templates/deployments/appname/app.jsonnet.tpl
+++ b/templates/deployments/appname/app.jsonnet.tpl
@@ -133,7 +133,7 @@ local all = {
 					Path: '/run/secrets/outreach.io/honeycomb/apiKey',
 				},
 				Dataset: if isDev then 'dev' else 'outreach',
-				SamplePercent: if isDev then 100 else 1,
+				SamplePercent: if isDev then 100 else 0.25,
 			},
 		} + if isDev then {
 			GlobalTags+: {


### PR DESCRIPTION
<!--
  !!!! README !!!! Please fill this out.

  Please follow the PR naming conventions: 
  https://outreach-io.atlassian.net/wiki/spaces/EN/pages/1902444645/Conventional+Commits
-->


<!-- A short description of what your PR does and what it solves. -->
## What this PR does / why we need it

This PR adjusts the default sample percent rate from `1%` to `0.25%` (1 in 400, this is also used @ Outreach for our Ruby codebase)

<!-- <<Stencil::Block(jiraPrefix)>> -->

## Jira ID

[DT-3669]

<!-- <</Stencil::Block>> -->

<!-- Notes that may be helpful for anyone reviewing this PR -->
## Notes for your reviewers



<!-- <<Stencil::Block(custom)>> -->

<!-- <</Stencil::Block>> -->


[DT-3669]: https://outreach-io.atlassian.net/browse/DT-3669?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ