### PR TITLE
fix(go): upgrade deps

### DIFF
--- a/templates/.snapshots/TestBasicGoMod-go.mod.tpl-go.mod.snapshot
+++ b/templates/.snapshots/TestBasicGoMod-go.mod.tpl-go.mod.snapshot
@@ -3,5 +3,5 @@
 go 1.19
 
 require (
-	github.com/getoutreach/gobox v1.68.1
+	github.com/getoutreach/gobox v1.70.1
 ))

--- a/templates/.snapshots/TestGoModStanzaVersion-go.mod.tpl-go.mod.snapshot
+++ b/templates/.snapshots/TestGoModStanzaVersion-go.mod.tpl-go.mod.snapshot
@@ -3,5 +3,5 @@
 go 1.19
 
 require (
-	github.com/getoutreach/gobox v1.68.1
+	github.com/getoutreach/gobox v1.70.1
 ))

--- a/templates/.snapshots/TestMergeGoMod-go.mod.tpl-go.mod.snapshot
+++ b/templates/.snapshots/TestMergeGoMod-go.mod.tpl-go.mod.snapshot
@@ -6,7 +6,7 @@ go 1.19
 
 require (
 	github.com/blang/semver/v4 v4.0.0
-	github.com/getoutreach/gobox v1.68.1
+	github.com/getoutreach/gobox v1.70.1
 	github.com/getoutreach/stencil v1.28.0-rc.2
 	github.com/pkg/errors v0.9.1
 	github.com/sirupsen/logrus v1.9.0

--- a/templates/.snapshots/TestRenderDependabot-.github-dependabot.yml.tpl-.github-dependabot.yml.snapshot
+++ b/templates/.snapshots/TestRenderDependabot-.github-dependabot.yml.tpl-.github-dependabot.yml.snapshot
@@ -11,6 +11,7 @@ updates:
       - dependency-name: github.com/getoutreach/gobox
       - dependency-name: google.golang.org/grpc
       - dependency-name: github.com/getoutreach/orgservice
+      - dependency-name: github.com/getoutreach/services
 
   # Ignore semantic-release, this code is only executed in CI.
   - package-ecosystem: "npm"

--- a/templates/_helpers.tpl
+++ b/templates/_helpers.tpl
@@ -101,13 +101,20 @@
 {{- define "dependencies" }}
 go:
 - name: github.com/getoutreach/gobox
-  version: v1.68.1
+  version: v1.70.1
 
 {{- if has "grpc" (stencil.Arg "serviceActivities") }}
 - name: google.golang.org/grpc
   version: v1.37.0
 - name: github.com/getoutreach/orgservice
   version: v1.63.0
+  # Used for grpcx
+- name: github.com/getoutreach/services
+  version: v1.143.0
+{{- end }}
+{{- if has "http" (stencil.Arg "serviceActivities") }}
+- name: github.com/getoutreach/httpx
+  version: v1.17.3
 {{- end }}
 
 {{- if stencil.Arg "commands" }}


### PR DESCRIPTION
<!--
  !!!! README !!!! Please fill this out.

  Please follow the PR naming conventions: 
  https://outreach-io.atlassian.net/wiki/spaces/EN/pages/1902444645/Conventional+Commits
-->


<!-- A short description of what your PR does and what it solves. -->
## What this PR does / why we need it

Updates the dependencies for Go projects, for the following reasons:

 * `httpx` - Fixes the HTTP server to be able to gracefully shutdown
 * `grpcx` - Add the ability to disable logs and/or traces for specific endpoints
 * `gobox` - Adds ability to silence logs emitted by the `trace.<*>Call` methods. Fixes a panic with the delibird logger integration.


<!-- <<Stencil::Block(jiraPrefix)>> -->

## Jira ID

[XX-XX]

<!-- <</Stencil::Block>> -->

<!-- Notes that may be helpful for anyone reviewing this PR -->
## Notes for your reviewers



<!-- <<Stencil::Block(custom)>> -->

<!-- <</Stencil::Block>> -->
