### PR TITLE
fix(vscode): use proper debugger paths for dlv debug

### DIFF
--- a/templates/.snapshots/TestVSCodeLaunchConfig-.vscode-launch.json.tpl-.vscode-launch.json.snapshot
+++ b/templates/.snapshots/TestVSCodeLaunchConfig-.vscode-launch.json.tpl-.vscode-launch.json.snapshot
@@ -1,4 +1,4 @@
-{
+(*codegen.File)({
   // Use IntelliSense to learn about possible attributes.
   // Hover to view descriptions of existing attributes.
   // For more information, visit: https://go.microsoft.com/fwlink/?linkid=830387
@@ -11,7 +11,7 @@
       "mode": "debug",
       "envFile": "${workspaceRoot}/.vscode/private.env",
       "go.testEnvFile": "${workspaceRoot}/.vscode/private.env",
-      "program": "${workspaceRoot}/cmd/{{ .Config.Name }}/",
+      "program": "${workspaceRoot}/cmd/testing/",
       "buildFlags": "-tags=or_dev"
     },
     {
@@ -21,14 +21,9 @@
       "request": "attach",
       "mode": "remote",
       // <<Stencil::Block(vscodeRemoteDebug)>>
-{{- if file.Block "vscodeRemoteDebug" }}
-{{ file.Block "vscodeRemoteDebug" }}
-{{- else }}
       "host": "127.0.0.1",
       "port": 42097,
-{{- end }}
       // <</Stencil::Block>>
-      {{- $goVersion := stencil.ApplyTemplate "goVersion" }}
       // Paths to replace when running the debugger. "from" is the host
       // path and "to" is the path in the devspace.
       "substitutePath": [
@@ -43,19 +38,20 @@
         // Maps the go module cache on the host to the persistent volume used by devspaces.
         // See the value of `go env GOMODCACHE` on the host and devspace.
         {
-          "from": "${env:HOME}/.asdf/installs/golang/{{ $goVersion }}/packages/pkg/mod",
+          "from": "${env:HOME}/.asdf/installs/golang/1.19.8/packages/pkg/mod",
           "to": "/tmp/cache/go/mod/"
         },
         {
           // Maps the standard library location on the host to the location in the devspace.
           // This enables debugging standard library code.
-          "from": "${env:HOME}/.asdf/installs/golang/{{ $goVersion }}/go/src",
-          "to": "/home/dev/.asdf/installs/golang/{{ $goVersion }}/go/src"
+          "from": "${env:HOME}/.asdf/installs/golang/1.19.8/go/src",
+          "to": "/home/dev/.asdf/installs/golang/1.19.8/go/src"
         }
       ],
     },
     // <<Stencil::Block(vscodeLaunchConfigs)>>
-{{ file.Block "vscodeLaunchConfigs" }}
+
     // <</Stencil::Block>>
   ]
 }
+)

--- a/templates/main_test.go
+++ b/templates/main_test.go
@@ -335,3 +335,11 @@ func TestDevspaceYaml(t *testing.T) {
 	})
 	st.Run(true)
 }
+
+func TestVSCodeLaunchConfig(t *testing.T) {
+	st := stenciltest.New(t, ".vscode/launch.json.tpl", libaryTmpls...)
+	st.Args(map[string]interface{}{
+		"service": true,
+	})
+	st.Run(true)
+}


### PR DESCRIPTION
<!--
  !!!! README !!!! Please fill this out.

  Please follow the PR naming conventions: 
  https://outreach-io.atlassian.net/wiki/spaces/EN/pages/1902444645/Conventional+Commits
-->


<!-- A short description of what your PR does and what it solves. -->
## What this PR does / why we need it

This PR fixes the local paths to no longer reply on `-trimpath`. When https://github.com/getoutreach/devbase/pull/510 landed, we stopped using `trimpath` (unobviously) which broke the debugger path substitution. While here, I added in-line code docs to make it easier to understand what each part is doing and why it exists.

I tested this locally on `keraton`.

## Jira ID

[DT-3746]



[DT-3746]: https://outreach-io.atlassian.net/browse/DT-3746?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ