### PR TITLE
fix: DT-3020 lll skips //go:generate lines

### DIFF
--- a/templates/scripts/golangci.yml.tpl
+++ b/templates/scripts/golangci.yml.tpl
@@ -101,6 +101,9 @@ issues:
       text: "SA5011"
       linters:
         - staticcheck
+    - linters:
+        - lll
+      source: "^//go:generate "
 
 output:
   format: colored-line-number


### PR DESCRIPTION
<!--
  !!!! README !!!! Please fill this out.

  Please follow the PR naming conventions: 
  https://outreach-io.atlassian.net/wiki/spaces/EN/pages/1902444645/Conventional+Commits
-->


<!-- A short description of what your PR does and what it solves. -->
## What this PR does / why we need it

//go:generate lines cannot be shortened. This rule prevents needing to add `nolint` for the many such lines that are longer than 140 characters.

<!-- <<Stencil::Block(jiraPrefix)>> -->

## Jira ID

[DT-3020]

<!-- <</Stencil::Block>> -->

<!-- Notes that may be helpful for anyone reviewing this PR -->
## Notes for your reviewers



<!-- <<Stencil::Block(custom)>> -->

<!-- <</Stencil::Block>> -->


[DT-3020]: https://outreach-io.atlassian.net/browse/DT-3020?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ