### PR TITLE
chore: Hotfix f356e8cd443fee79eb3754e60bcb493231acec52 into channel stable

### DIFF
--- a/templates/.snapshots/TestBasicGoMod-go.mod.tpl-go.mod.snapshot
+++ b/templates/.snapshots/TestBasicGoMod-go.mod.tpl-go.mod.snapshot
@@ -3,5 +3,5 @@
 go 1.19
 
 require (
-	github.com/getoutreach/gobox v1.70.1
+	github.com/getoutreach/gobox v1.70.4
 ))

--- a/templates/.snapshots/TestGoModStanzaVersion-go.mod.tpl-go.mod.snapshot
+++ b/templates/.snapshots/TestGoModStanzaVersion-go.mod.tpl-go.mod.snapshot
@@ -3,5 +3,5 @@
 go 1.19
 
 require (
-	github.com/getoutreach/gobox v1.70.1
+	github.com/getoutreach/gobox v1.70.4
 ))

--- a/templates/.snapshots/TestMergeGoMod-go.mod.tpl-go.mod.snapshot
+++ b/templates/.snapshots/TestMergeGoMod-go.mod.tpl-go.mod.snapshot
@@ -6,7 +6,7 @@ go 1.19
 
 require (
 	github.com/blang/semver/v4 v4.0.0
-	github.com/getoutreach/gobox v1.70.1
+	github.com/getoutreach/gobox v1.70.4
 	github.com/getoutreach/stencil v1.28.0-rc.2
 	github.com/pkg/errors v0.9.1
 	github.com/sirupsen/logrus v1.9.0

--- a/templates/_helpers.tpl
+++ b/templates/_helpers.tpl
@@ -101,7 +101,7 @@
 {{- define "dependencies" }}
 go:
 - name: github.com/getoutreach/gobox
-  version: v1.70.1
+  version: v1.70.4
 
 {{- if has "grpc" (stencil.Arg "serviceActivities") }}
 - name: google.golang.org/grpc
@@ -110,7 +110,7 @@ go:
   version: v1.63.0
   # Used for grpcx
 - name: github.com/getoutreach/services
-  version: v1.143.0
+  version: v1.152.1
 {{- end }}
 {{- if has "http" (stencil.Arg "serviceActivities") }}
 - name: github.com/getoutreach/httpx


### PR DESCRIPTION
Hotfixes commit(s) "f356e8cd443fee79eb3754e60bcb493231acec52" into channel stable, created by `dt release hotfix`

**DO NOT MERGE**