### PR TITLE
fix(deps): update gobox

### DIFF
--- a/templates/.snapshots/TestBasicGoMod-go.mod.tpl-go.mod.snapshot
+++ b/templates/.snapshots/TestBasicGoMod-go.mod.tpl-go.mod.snapshot
@@ -3,5 +3,5 @@
 go 1.19
 
 require (
-	github.com/getoutreach/gobox v1.70.4
+	github.com/getoutreach/gobox v1.70.5
 ))

--- a/templates/.snapshots/TestGoModStanzaVersion-go.mod.tpl-go.mod.snapshot
+++ b/templates/.snapshots/TestGoModStanzaVersion-go.mod.tpl-go.mod.snapshot
@@ -3,5 +3,5 @@
 go 1.19
 
 require (
-	github.com/getoutreach/gobox v1.70.4
+	github.com/getoutreach/gobox v1.70.5
 ))

--- a/templates/.snapshots/TestMergeGoMod-go.mod.tpl-go.mod.snapshot
+++ b/templates/.snapshots/TestMergeGoMod-go.mod.tpl-go.mod.snapshot
@@ -6,7 +6,7 @@ go 1.19
 
 require (
 	github.com/blang/semver/v4 v4.0.0
-	github.com/getoutreach/gobox v1.70.4
+	github.com/getoutreach/gobox v1.70.5
 	github.com/getoutreach/stencil v1.28.0-rc.2
 	github.com/pkg/errors v0.9.1
 	github.com/sirupsen/logrus v1.9.0

--- a/templates/_helpers.tpl
+++ b/templates/_helpers.tpl
@@ -101,7 +101,7 @@
 {{- define "dependencies" }}
 go:
 - name: github.com/getoutreach/gobox
-  version: v1.70.4
+  version: v1.70.5
 
 {{- if has "grpc" (stencil.Arg "serviceActivities") }}
 - name: google.golang.org/grpc


### PR DESCRIPTION
This fixes an issue with delibird where stdin would not be hooked up to
the child process when stdin is not a terminal.

[DT-3742]

[DT-3742]: https://outreach-io.atlassian.net/browse/DT-3742?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ