### PR TITLE
fix: revert disabling dlv port forwarding by default

### DIFF
--- a/templates/.snapshots/TestDevspaceYaml-devspace.yaml.tpl-devspace.yaml.snapshot
+++ b/templates/.snapshots/TestDevspaceYaml-devspace.yaml.tpl-devspace.yaml.snapshot
@@ -307,13 +307,15 @@ profiles:
               app: ${DEVENV_DEPLOY_APPNAME}
 
   - name: skipPortForwarding
-    description: Skip port-forwarding entirely
+    description: Skip port-forwarding for all but the DLV port.
     activation:
       - vars:
           DEVENV_DEV_SKIP_PORTFORWARDING: "true"
     patches:
-      - op: remove
+      - op: replace
         path: dev.app.ports
+        value: 
+          - port: ${DLV_PORT}
 
   - name: e2e
     activation:

--- a/templates/devspace.yaml.tpl
+++ b/templates/devspace.yaml.tpl
@@ -331,13 +331,15 @@ profiles:
               app: ${DEVENV_DEPLOY_APPNAME}
 
   - name: skipPortForwarding
-    description: Skip port-forwarding entirely
+    description: Skip port-forwarding for all but the DLV port.
     activation:
       - vars:
           DEVENV_DEV_SKIP_PORTFORWARDING: "true"
     patches:
-      - op: remove
+      - op: replace
         path: dev.app.ports
+        value: 
+          - port: ${DLV_PORT}
 
   - name: e2e
     activation:


### PR DESCRIPTION
<!--
  !!!! README !!!! Please fill this out.

  Please follow the PR naming conventions: 
  https://outreach-io.atlassian.net/wiki/spaces/EN/pages/1902444645/Conventional+Commits
-->


<!-- A short description of what your PR does and what it solves. -->
## What this PR does / why we need it
This specifically reverts the change to disable forwarding the DLV port by default. The functionality to override this port with an environmental variable will still exist, and that's a viable path forward to support deploying/debugging multiple applications to devspace.


<!-- <<Stencil::Block(jiraPrefix)>> -->

## Jira ID

[XX-XX]

<!-- <</Stencil::Block>> -->

<!-- Notes that may be helpful for anyone reviewing this PR -->
## Notes for your reviewers



<!-- <<Stencil::Block(custom)>> -->

<!-- <</Stencil::Block>> -->
