### PR TITLE
feat: Add basic binary sync mode for devspace

### DIFF
--- a/templates/.snapshots/TestDevspaceYaml-devspace.yaml.tpl-devspace.yaml.snapshot
+++ b/templates/.snapshots/TestDevspaceYaml-devspace.yaml.tpl-devspace.yaml.snapshot
@@ -390,15 +390,6 @@ profiles:
             disableDownload: true
             waitInitialSync: true
       - op: add
-        path: dev.app.patches
-        value: 
-          op: replace
-          path: spec.containers[0].resources
-          value:
-            limits:
-              cpu: 200m
-              memory: 400Mi
-      - op: add
         path: hooks
         value:
           name: reset-dev

--- a/templates/.snapshots/TestDevspaceYaml-devspace.yaml.tpl-devspace.yaml.snapshot
+++ b/templates/.snapshots/TestDevspaceYaml-devspace.yaml.tpl-devspace.yaml.snapshot
@@ -393,10 +393,11 @@ profiles:
         path: dev.app.patches
         value: 
           op: replace
-          path: spec.containers[0].resources.limits
+          path: spec.containers[0].resources
           value:
-            cpu: 200m
-            memory: 400Mi
+            limits:
+              cpu: 200m
+              memory: 400Mi
       - op: add
         path: hooks
         value:

--- a/templates/.snapshots/TestDevspaceYaml-devspace.yaml.tpl-devspace.yaml.snapshot
+++ b/templates/.snapshots/TestDevspaceYaml-devspace.yaml.tpl-devspace.yaml.snapshot
@@ -319,7 +319,6 @@ profiles:
     activation:
       - vars:
           DEVENV_DEV_SKIP_PORTFORWARDING: "true"
-          DEVENV_SYNC_BINARIES: "false"
     patches:
       - op: replace
         path: dev.app.ports
@@ -397,7 +396,7 @@ profiles:
           path: spec.containers[0].resources.limits
           value:
             cpu: 200m
-            memory: 200Mi
+            memory: 400Mi
       - op: add
         path: hooks
         value:

--- a/templates/.snapshots/TestDevspaceYaml-devspace.yaml.tpl-devspace.yaml.snapshot
+++ b/templates/.snapshots/TestDevspaceYaml-devspace.yaml.tpl-devspace.yaml.snapshot
@@ -413,7 +413,7 @@ profiles:
             disableReplace: true
             workDir: ${DEV_CONTAINER_WORKDIR}
             command: |-
-              ../entrypoint.sh
+              entrypoint
 
   # App Profiles
   # Profiles starting with deployment__ are treated specially by devenv.

--- a/templates/.snapshots/TestDevspaceYaml-devspace.yaml.tpl-devspace.yaml.snapshot
+++ b/templates/.snapshots/TestDevspaceYaml-devspace.yaml.tpl-devspace.yaml.snapshot
@@ -24,6 +24,12 @@ vars:
   DEVENV_DEPLOY_VERSION:
     source: env
     default: "latest"
+  # DEVENV_SYNC_BINARIES:
+  # false: Devspace is build machine that synchronizes source code and runs it
+  # true: Devspace synchronizes binaries and run them
+  DEVENV_SYNC_BINARIES:
+    source: env
+    default: "false"
   DEVENV_DEPLOY_IMAGE_SOURCE:
     source: env
     default: local
@@ -249,6 +255,32 @@ hooks:
     events: ["before:build"]
   
 profiles:
+  - name: binarySync
+    description: Synchronizes just content of bin folder and don't do any build related stuff in the devspace pod
+    activation:
+      - vars:
+          DEVENV_SYNC_BINARIES: "true"
+    patches:
+      - op: replace
+        path: dev.app.devImage
+        value: gcr.io/outreach-docker/bootstrap/dev-slim:stable
+      - op: replace
+        path: dev.app.sync
+        value: 
+          - path: ./bin:${DEV_CONTAINER_WORKDIR}
+            printLogs: true
+            disableDownload: true
+            waitInitialSync: true
+    merge:
+      dev:
+        app:
+          # https://www.devspace.sh/docs/configuration/dev/#dev-terminal
+          terminal:
+            enabled: true
+            disableReplace: true
+            workDir: ${DEV_CONTAINER_WORKDIR}
+            command: |-
+              ./entrypoint.sh
   - name: devTerminal
     description: dev command opens a terminal into dev container. Automatically activated based on $DEVENV_DEV_TERMINAL == true var.
     activation:

--- a/templates/.snapshots/TestDevspaceYaml-devspace.yaml.tpl-devspace.yaml.snapshot
+++ b/templates/.snapshots/TestDevspaceYaml-devspace.yaml.tpl-devspace.yaml.snapshot
@@ -255,37 +255,12 @@ hooks:
     events: ["before:build"]
   
 profiles:
-  - name: binarySync
-    description: Synchronizes just content of bin folder and don't do any build related stuff in the devspace pod
-    activation:
-      - vars:
-          DEVENV_SYNC_BINARIES: "true"
-    patches:
-      - op: replace
-        path: dev.app.devImage
-        value: gcr.io/outreach-docker/bootstrap/dev-slim:stable
-      - op: replace
-        path: dev.app.sync
-        value: 
-          - path: ./bin:${DEV_CONTAINER_WORKDIR}
-            printLogs: true
-            disableDownload: true
-            waitInitialSync: true
-    merge:
-      dev:
-        app:
-          # https://www.devspace.sh/docs/configuration/dev/#dev-terminal
-          terminal:
-            enabled: true
-            disableReplace: true
-            workDir: ${DEV_CONTAINER_WORKDIR}
-            command: |-
-              ./entrypoint.sh
   - name: devTerminal
     description: dev command opens a terminal into dev container. Automatically activated based on $DEVENV_DEV_TERMINAL == true var.
     activation:
       - vars:
           DEVENV_DEV_TERMINAL: "true"
+          DEVENV_SYNC_BINARIES: "false"
     patches:
       - op: add
         path: hooks
@@ -310,6 +285,7 @@ profiles:
     activation:
       - vars:
           DEVENV_DEV_TERMINAL: "false"
+          DEVENV_SYNC_BINARIES: "false"
     patches:
       - op: add
         path: hooks
@@ -343,6 +319,7 @@ profiles:
     activation:
       - vars:
           DEVENV_DEV_SKIP_PORTFORWARDING: "true"
+          DEVENV_SYNC_BINARIES: "false"
     patches:
       - op: replace
         path: dev.app.ports
@@ -354,6 +331,7 @@ profiles:
       - env:
           E2E: "true"
           DEVENV_DEV_TERMINAL: "false"
+          DEVENV_SYNC_BINARIES: "false"
     patches:
       - op: add
         path: dev.app.patches
@@ -379,6 +357,7 @@ profiles:
       - env:
           E2E: "true"
           DEVENV_DEV_TERMINAL: "true"
+          DEVENV_SYNC_BINARIES: "false"
     patches:
       - op: add
         path: dev.app.patches
@@ -394,6 +373,48 @@ profiles:
           value:
             name: E2E
             value: "true"
+
+  - name: binarySync
+    description: Synchronizes just content of bin folder and don't do any build related stuff in the devspace pod
+    activation:
+      - vars:
+          DEVENV_SYNC_BINARIES: "true"
+    patches:
+      - op: replace
+        path: dev.app.devImage
+        value: gcr.io/outreach-docker/bootstrap/dev-slim:stable
+      - op: replace
+        path: dev.app.sync
+        value:
+          - path: ./bin:${DEV_CONTAINER_WORKDIR}
+            printLogs: true
+            disableDownload: true
+            waitInitialSync: true
+      - op: add
+        path: dev.app.patches
+        value: 
+          op: replace
+          path: spec.containers[0].resources.limits
+          value:
+            cpu: 200m
+            memory: 200Mi
+      - op: add
+        path: hooks
+        value:
+          name: reset-dev
+          events: ["devCommand:after:execute"]
+          command: |-
+            "${DEVENV_DEVSPACE_BIN}" reset pods -s
+    merge: 
+      dev:
+        app:
+          # https://www.devspace.sh/docs/configuration/dev/#dev-terminal
+          terminal:
+            enabled: true
+            disableReplace: true
+            workDir: ${DEV_CONTAINER_WORKDIR}
+            command: |-
+              ../entrypoint.sh
 
   # App Profiles
   # Profiles starting with deployment__ are treated specially by devenv.

--- a/templates/.snapshots/TestVSCodeLaunchConfig-.vscode-launch.json.tpl-.vscode-launch.json.snapshot
+++ b/templates/.snapshots/TestVSCodeLaunchConfig-.vscode-launch.json.tpl-.vscode-launch.json.snapshot
@@ -49,6 +49,17 @@
         }
       ],
     },
+    {
+      "name": "Attach to dev container (in binary mode)",
+      "type": "go",
+      "debugAdapter": "dlv-dap",
+      "request": "attach",
+      "mode": "remote",
+      // <<Stencil::Block(vscodeRemoteDebug)>>
+      "host": "127.0.0.1",
+      "port": 42097,
+      // <</Stencil::Block>>
+    },
     // <<Stencil::Block(vscodeLaunchConfigs)>>
 
     // <</Stencil::Block>>

--- a/templates/.snapshots/TestVSCodeLaunchConfig-.vscode-launch.json.tpl-.vscode-launch.json.snapshot
+++ b/templates/.snapshots/TestVSCodeLaunchConfig-.vscode-launch.json.tpl-.vscode-launch.json.snapshot
@@ -55,7 +55,7 @@
       "debugAdapter": "dlv-dap",
       "request": "attach",
       "mode": "remote",
-      // <<Stencil::Block(vscodeRemoteDebug)>>
+      // <<Stencil::Block(vscodeRemoteDebugDevspaceBinary)>>
       "host": "127.0.0.1",
       "port": 42097,
       // <</Stencil::Block>>

--- a/templates/.vscode/launch.json.tpl
+++ b/templates/.vscode/launch.json.tpl
@@ -54,6 +54,22 @@
         }
       ],
     },
+    {
+      "name": "Attach to dev container (in binary mode)",
+      "type": "go",
+      "debugAdapter": "dlv-dap",
+      "request": "attach",
+      "mode": "remote",
+      // <<Stencil::Block(vscodeRemoteDebug)>>
+{{- if file.Block "vscodeRemoteDebug" }}
+{{ file.Block "vscodeRemoteDebug" }}
+{{- else }}
+      "host": "127.0.0.1",
+      "port": 42097,
+{{- end }}
+      // <</Stencil::Block>>
+      {{- $goVersion := stencil.ApplyTemplate "goVersion" }}
+    },
     // <<Stencil::Block(vscodeLaunchConfigs)>>
 {{ file.Block "vscodeLaunchConfigs" }}
     // <</Stencil::Block>>

--- a/templates/.vscode/launch.json.tpl
+++ b/templates/.vscode/launch.json.tpl
@@ -60,9 +60,9 @@
       "debugAdapter": "dlv-dap",
       "request": "attach",
       "mode": "remote",
-      // <<Stencil::Block(vscodeRemoteDebug)>>
-{{- if file.Block "vscodeRemoteDebug" }}
-{{ file.Block "vscodeRemoteDebug" }}
+      // <<Stencil::Block(vscodeRemoteDebugDevspaceBinary)>>
+{{- if file.Block "vscodeRemoteDebugDevspaceBinary" }}
+{{ file.Block "vscodeRemoteDebugDevspaceBinary" }}
 {{- else }}
       "host": "127.0.0.1",
       "port": 42097,

--- a/templates/devspace.yaml.tpl
+++ b/templates/devspace.yaml.tpl
@@ -284,6 +284,7 @@ profiles:
     activation:
       - vars:
           DEVENV_DEV_TERMINAL: "true"
+          DEVENV_SYNC_BINARIES: "false"
     patches:
       - op: add
         path: hooks
@@ -308,6 +309,7 @@ profiles:
     activation:
       - vars:
           DEVENV_DEV_TERMINAL: "false"
+          DEVENV_SYNC_BINARIES: "false"
     patches:
       - op: add
         path: hooks
@@ -341,6 +343,7 @@ profiles:
     activation:
       - vars:
           DEVENV_DEV_SKIP_PORTFORWARDING: "true"
+          DEVENV_SYNC_BINARIES: "false"
     patches:
       - op: replace
         path: dev.app.ports
@@ -352,6 +355,7 @@ profiles:
       - env:
           E2E: "true"
           DEVENV_DEV_TERMINAL: "false"
+          DEVENV_SYNC_BINARIES: "false"
     patches:
       - op: add
         path: dev.app.patches
@@ -377,6 +381,7 @@ profiles:
       - env:
           E2E: "true"
           DEVENV_DEV_TERMINAL: "true"
+          DEVENV_SYNC_BINARIES: "false"
     patches:
       - op: add
         path: dev.app.patches
@@ -417,6 +422,13 @@ profiles:
           value:
             cpu: 200m
             memory: 200Mi
+      - op: add
+        path: hooks
+        value:
+          name: reset-dev
+          events: ["devCommand:after:execute"]
+          command: |-
+            "${DEVENV_DEVSPACE_BIN}" reset pods -s
     merge: 
       dev:
         app:

--- a/templates/devspace.yaml.tpl
+++ b/templates/devspace.yaml.tpl
@@ -343,7 +343,6 @@ profiles:
     activation:
       - vars:
           DEVENV_DEV_SKIP_PORTFORWARDING: "true"
-          DEVENV_SYNC_BINARIES: "false"
     patches:
       - op: replace
         path: dev.app.ports
@@ -421,7 +420,7 @@ profiles:
           path: spec.containers[0].resources.limits
           value:
             cpu: 200m
-            memory: 200Mi
+            memory: 400Mi
       - op: add
         path: hooks
         value:

--- a/templates/devspace.yaml.tpl
+++ b/templates/devspace.yaml.tpl
@@ -438,7 +438,7 @@ profiles:
             disableReplace: true
             workDir: ${DEV_CONTAINER_WORKDIR}
             command: |-
-              ./entrypoint.sh
+              ../entrypoint.sh
 
   # App Profiles
   # Profiles starting with deployment__ are treated specially by devenv.

--- a/templates/devspace.yaml.tpl
+++ b/templates/devspace.yaml.tpl
@@ -414,15 +414,6 @@ profiles:
             disableDownload: true
             waitInitialSync: true
       - op: add
-        path: dev.app.patches
-        value: 
-          op: replace
-          path: spec.containers[0].resources
-          value:
-            limits:
-              cpu: 200m
-              memory: 400Mi
-      - op: add
         path: hooks
         value:
           name: reset-dev

--- a/templates/devspace.yaml.tpl
+++ b/templates/devspace.yaml.tpl
@@ -279,32 +279,6 @@ hooks:
     events: ["before:build"]
   
 profiles:
-  - name: binarySync
-    description: Synchronizes just content of bin folder and don't do any build related stuff in the devspace pod
-    activation:
-      - vars:
-          DEVENV_SYNC_BINARIES: "true"
-    patches:
-      - op: replace
-        path: dev.app.devImage
-        value: gcr.io/outreach-docker/bootstrap/dev-slim:stable
-      - op: replace
-        path: dev.app.sync
-        value: 
-          - path: ./bin:${DEV_CONTAINER_WORKDIR}
-            printLogs: true
-            disableDownload: true
-            waitInitialSync: true
-    merge:
-      dev:
-        app:
-          # https://www.devspace.sh/docs/configuration/dev/#dev-terminal
-          terminal:
-            enabled: true
-            disableReplace: true
-            workDir: ${DEV_CONTAINER_WORKDIR}
-            command: |-
-              ./entrypoint.sh
   - name: devTerminal
     description: dev command opens a terminal into dev container. Automatically activated based on $DEVENV_DEV_TERMINAL == true var.
     activation:
@@ -418,6 +392,41 @@ profiles:
           value:
             name: E2E
             value: "true"
+
+  - name: binarySync
+    description: Synchronizes just content of bin folder and don't do any build related stuff in the devspace pod
+    activation:
+      - vars:
+          DEVENV_SYNC_BINARIES: "true"
+    patches:
+      - op: replace
+        path: dev.app.devImage
+        value: gcr.io/outreach-docker/bootstrap/dev-slim:stable
+      - op: replace
+        path: dev.app.sync
+        value:
+          - path: ./bin:${DEV_CONTAINER_WORKDIR}
+            printLogs: true
+            disableDownload: true
+            waitInitialSync: true
+      - op: add
+        path: dev.app.patches
+        value: 
+          op: replace
+          path: spec.containers[0].resources.limits
+          value:
+            cpu: 200m
+            memory: 200Mi
+    merge: 
+      dev:
+        app:
+          # https://www.devspace.sh/docs/configuration/dev/#dev-terminal
+          terminal:
+            enabled: true
+            disableReplace: true
+            workDir: ${DEV_CONTAINER_WORKDIR}
+            command: |-
+              ./entrypoint.sh
 
   # App Profiles
   # Profiles starting with deployment__ are treated specially by devenv.

--- a/templates/devspace.yaml.tpl
+++ b/templates/devspace.yaml.tpl
@@ -437,7 +437,7 @@ profiles:
             disableReplace: true
             workDir: ${DEV_CONTAINER_WORKDIR}
             command: |-
-              ../entrypoint.sh
+              entrypoint
 
   # App Profiles
   # Profiles starting with deployment__ are treated specially by devenv.

--- a/templates/devspace.yaml.tpl
+++ b/templates/devspace.yaml.tpl
@@ -417,10 +417,11 @@ profiles:
         path: dev.app.patches
         value: 
           op: replace
-          path: spec.containers[0].resources.limits
+          path: spec.containers[0].resources
           value:
-            cpu: 200m
-            memory: 400Mi
+            limits:
+              cpu: 200m
+              memory: 400Mi
       - op: add
         path: hooks
         value:


### PR DESCRIPTION
<!--
  !!!! README !!!! Please fill this out.

  Please follow the PR naming conventions: 
  https://outreach-io.atlassian.net/wiki/spaces/EN/pages/1902444645/Conventional+Commits
-->


<!-- A short description of what your PR does and what it solves. -->
## What this PR does / why we need it
Add support for binary sync in devspace mode. This way we don't need to make dev machine out of devspace pod, but just synchronize binaries and have file system watcher on dev-slim package.


<!-- <<Stencil::Block(jiraPrefix)>> -->

## Jira ID

[QF-880]

<!-- <</Stencil::Block>> -->

<!-- Notes that may be helpful for anyone reviewing this PR -->
## Notes for your reviewers



<!-- <<Stencil::Block(custom)>> -->

<!-- <</Stencil::Block>> -->


[QF-880]: https://outreach-io.atlassian.net/browse/QF-880?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ