### PR TITLE
feat: include kubernetes leaderelection option

### DIFF
--- a/manifest.yaml
+++ b/manifest.yaml
@@ -75,6 +75,11 @@ arguments:
       items:
         type: object
     description: List of Kubernetes groups to generate
+  kubernetes.leaderElection:
+    schema:
+      type: boolean
+    default: true
+    description: Have stencil render code related to leader election for kubernetes operators/webhooks/controllers
   lintroller:
     schema:
       type: string


### PR DESCRIPTION
<!--
  !!!! README !!!! Please fill this out.

  Please follow the PR naming conventions: 
  https://outreach-io.atlassian.net/wiki/spaces/EN/pages/1902444645/Conventional+Commits
-->


<!-- A short description of what your PR does and what it solves. -->
## What this PR does / why we need it
Adds a leader election option to manifest.yaml so that kubernetes controllers/webhooks/operators can have this disabled.

Also fixes a bug around ctrlOptions being declared and never used, and a duplicate registration of ConfigMaps.


<!-- <<Stencil::Block(jiraPrefix)>> -->

## Jira ID

[DT-3816]

<!-- <</Stencil::Block>> -->

<!-- Notes that may be helpful for anyone reviewing this PR -->
## Notes for your reviewers



<!-- <<Stencil::Block(custom)>> -->

<!-- <</Stencil::Block>> -->


[DT-3816]: https://outreach-io.atlassian.net/browse/DT-3816?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ