### PR TITLE
feat(vscode): remove trailing whitespace on save

### DIFF
--- a/templates/.vscode/settings.json.tpl
+++ b/templates/.vscode/settings.json.tpl
@@ -14,6 +14,7 @@
   },
   "go.buildTags": "or_dev",
   "go.testTags": "or_test,or_int,or_e2e",
+  "files.trimTrailingWhitespace": true,
   // This prevents 99% of issues with linters :)
   "editor.formatOnSave": true,
   "shellcheck.customArgs": [


### PR DESCRIPTION
## What this PR does / why we need it

Avoids PRs which add trailing whitespace, followed by PRs which run `make fmt`.