### PR TITLE
fix: Upper bound for datadog terraform provider

### DIFF
--- a/templates/monitoring/versions.tf.tpl
+++ b/templates/monitoring/versions.tf.tpl
@@ -5,7 +5,7 @@ terraform {
   required_providers {
     datadog = {
       source  = "datadog/datadog"
-      version = ">= 2.20.0, < 3.0.0"
+      version = ">= 3.0.0, < 3.27.0"
     }
     vault = {
       source = "hashicorp/vault"

--- a/templates/monitoring/versions.tf.tpl
+++ b/templates/monitoring/versions.tf.tpl
@@ -5,7 +5,7 @@ terraform {
   required_providers {
     datadog = {
       source  = "datadog/datadog"
-      version = ">= 2.20.0"
+      version = ">= 2.20.0, < 3.0.0"
     }
     vault = {
       source = "hashicorp/vault"

--- a/templates/monitoring/versions.tf.tpl
+++ b/templates/monitoring/versions.tf.tpl
@@ -5,7 +5,7 @@ terraform {
   required_providers {
     datadog = {
       source  = "datadog/datadog"
-      version = ">= 3.0.0, < 3.27.0"
+      version = ">= 3.0.0, < 4.0.0"
     }
     vault = {
       source = "hashicorp/vault"


### PR DESCRIPTION
<!--
  !!!! README !!!! Please fill this out.

  Please follow the PR naming conventions: 
  https://outreach-io.atlassian.net/wiki/spaces/EN/pages/1902444645/Conventional+Commits
-->


<!-- A short description of what your PR does and what it solves. -->
## What this PR does / why we need it

This PR puts an upper bound on the datadog terraform provider version. It looks like a recent version broke something and this prevents us from using that version.

<!-- <<Stencil::Block(jiraPrefix)>> -->

## Jira ID

[DT-3874]

<!-- <</Stencil::Block>> -->

<!-- Notes that may be helpful for anyone reviewing this PR -->
## Notes for your reviewers



<!-- <<Stencil::Block(custom)>> -->

<!-- <</Stencil::Block>> -->


[DT-3874]: https://outreach-io.atlassian.net/browse/DT-3874?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ