### PR TITLE
feat: Go 1.19.11, alpine 3.18, update build tooling

### DIFF
--- a/manifest.yaml
+++ b/manifest.yaml
@@ -235,14 +235,14 @@ arguments:
     default: ""
   versions.go:
     description: Go version to use
-    default: "1.19.8"
+    default: "1.19.11"
     schema:
       type:
         - string
         - number
   versions.nodejs:
     description: Nodejs version to use for build tooling (e.g., semantic-release)
-    default: "18.14.1"
+    default: "18.17.0"
     schema:
       type:
         - string
@@ -263,7 +263,7 @@ arguments:
         - number
   versions.alpine:
     description: Alpine version to use
-    default: "3.16"
+    default: "3.18"
     schema:
       type:
         - string

--- a/templates/.snapshots/TestRenderDeploymentDockerfile-deployments-appname-Dockerfile.tpl-deployments-testing-Dockerfile.snapshot
+++ b/templates/.snapshots/TestRenderDeploymentDockerfile-deployments-appname-Dockerfile.tpl-deployments-testing-Dockerfile.snapshot
@@ -1,5 +1,5 @@
 (*codegen.File)(# syntax=docker/dockerfile:1.0-experimental
-FROM gcr.io/outreach-docker/golang:1.19.8 as builder
+FROM gcr.io/outreach-docker/golang:1.19.11 as builder
 ARG VERSION
 ENV GOCACHE "/go-build-cache"
 ENV GOPRIVATE github.com/getoutreach/*

--- a/templates/.snapshots/TestVSCodeLaunchConfig-.vscode-launch.json.tpl-.vscode-launch.json.snapshot
+++ b/templates/.snapshots/TestVSCodeLaunchConfig-.vscode-launch.json.tpl-.vscode-launch.json.snapshot
@@ -38,14 +38,14 @@
         // Maps the go module cache on the host to the persistent volume used by devspaces.
         // See the value of `go env GOMODCACHE` on the host and devspace.
         {
-          "from": "${env:HOME}/.asdf/installs/golang/1.19.8/packages/pkg/mod",
+          "from": "${env:HOME}/.asdf/installs/golang/1.19.11/packages/pkg/mod",
           "to": "/tmp/cache/go/mod/"
         },
         {
           // Maps the standard library location on the host to the location in the devspace.
           // This enables debugging standard library code.
-          "from": "${env:HOME}/.asdf/installs/golang/1.19.8/go/src",
-          "to": "/home/dev/.asdf/installs/golang/1.19.8/go/src"
+          "from": "${env:HOME}/.asdf/installs/golang/1.19.11/go/src",
+          "to": "/home/dev/.asdf/installs/golang/1.19.11/go/src"
         }
       ],
     },


### PR DESCRIPTION
Upgrades Go `1.19.11` to fix some vulnerabilies, most notably
CVE-2023-29405[1].

Upgrades alpine to 3.18 for base image updates.

Updates build tooling (node.js) since it's good to keep close to LTS.

[1]: https://access.redhat.com/security/cve/CVE-2023-29405
