### PR TITLE
fix: ORCS-3222 fix devspace e2e activation

### DIFF
--- a/templates/.snapshots/TestDevspaceYaml-devspace.yaml.tpl-devspace.yaml.snapshot
+++ b/templates/.snapshots/TestDevspaceYaml-devspace.yaml.tpl-devspace.yaml.snapshot
@@ -53,6 +53,9 @@ vars:
   DEVENV_DEV_DEPLOYMENT_PROFILE:
     source: env
     default: deployment__testing
+  E2E:
+    source: env
+    default: "false"
   
 
   # devenv passes in paths to binaries it uses (ensuring the supported versions are used)
@@ -318,7 +321,7 @@ profiles:
 
   - name: e2e
     activation:
-      - env:
+      - vars:
           E2E: "true"
           DEVENV_DEV_TERMINAL: "false"
           DEVENV_SYNC_BINARIES: "false"
@@ -344,7 +347,7 @@ profiles:
 
   - name: e2eWithTerminal
     activation:
-      - env:
+      - vars:
           E2E: "true"
           DEVENV_DEV_TERMINAL: "true"
           DEVENV_SYNC_BINARIES: "false"

--- a/templates/devspace.yaml.tpl
+++ b/templates/devspace.yaml.tpl
@@ -54,6 +54,9 @@ vars:
   DEVENV_DEV_DEPLOYMENT_PROFILE:
     source: env
     default: deployment__{{ .Config.Name }}
+  E2E:
+    source: env
+    default: "false"
   
 
   # devenv passes in paths to binaries it uses (ensuring the supported versions are used)
@@ -342,7 +345,7 @@ profiles:
 
   - name: e2e
     activation:
-      - env:
+      - vars:
           E2E: "true"
           DEVENV_DEV_TERMINAL: "false"
           DEVENV_SYNC_BINARIES: "false"
@@ -368,7 +371,7 @@ profiles:
 
   - name: e2eWithTerminal
     activation:
-      - env:
+      - vars:
           E2E: "true"
           DEVENV_DEV_TERMINAL: "true"
           DEVENV_SYNC_BINARIES: "false"


### PR DESCRIPTION
[ORCS-3222](https://outreach-io.atlassian.net/browse/ORCS-3222)

Fixes a bug that prevented the e2e-specific sections of `devspace.yml`
from activating when they ought to.

I ran into this bug while working on the linked ticket.  Running `devenv
apps e2e` or `devenv apps e2e -t`, I'd find that the pod this created
used the regular k8s service account, not the special one set aside for
e2e tests.

----

What was the bug and how does this commit fix it?  That's a good
question with a long answer.

When I run `devenv apps e2e -t`, this is the command that gets invoked:
```
DEPLOY_TO_DEV_VERSION=latest DEVENV_BIN=/home/rlarocque/.outreach/bin/devenv DEVENV_VERSION=v1.58.0 DEVENV_DEPLOY_VERSION=latest DEVENV_DEPLOY_IMAGE_SOURCE=remote DEVENV_DEPLOY_IMAGE_REGISTRY=gcr.io/outreach-docker DEVENV_DEPLOY_DEV_IMAGE_REGISTRY=devenv.local DEVENV_DEPLOY_BOX_IMAGE_REGISTRY=gcr.io/outreach-docker DEVENV_DEPLOY_APPNAME=copycat DEVENV_TYPE=kind DEVENV_KIND_BIN=noop DEVSPACE_FLAGS=--var=IMAGE_REGISTRY=gcr.io/outreach-docker DEVENV_DEVSPACE_BIN=/home/rlarocque/.local/dev-environment/.deps/devspace-v6.3.2 DEVENV_DEV_TERMINAL=true DEVENV_DEV_SKIP_PORTFORWARDING=true E2E=true devspace dev --config /home/rlarocque/src/copycat/devspace.yaml --namespace copycat--bento1a --no-warn
```

If we replace the `devspace dev` part with `devspace print`, we can
debug what it's actually doing.  After my changes, we see this block in
the output.
```
- op: replace
  path: spec.serviceAccountName
  value: copycat-e2e-client-svc
```
Without my changes, we do not.

Again: why?

I think the reason why those paches weren't being picked up is that
their activation is gated on an `env`-based selector:
```
  - name: e2eWithTerminal
    activation:
      - env:
          E2E: "true"
          DEVENV_DEV_TERMINAL: "true"
          DEVENV_SYNC_BINARIES: "false"
```

But `DEVENV_SYNC_BINARIES` is not an environment variable.  That big
list of environment variables in the `devspace dev` command above
doesn't include it.

We can change the activation to be `vars`-based, like most of the other
profiles, but that in itself is not sufficient because `E2E` is a mere
environment variable and not a "devspace vars".  The change in the
`vars` section in this PR fixes that issue, and that is enough to get
activation working as it ought to.

[ORCS-3222]: https://outreach-io.atlassian.net/browse/ORCS-3222?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ