### PR TITLE
feat: add configmap md5 annotation to deployments

### DIFF
--- a/templates/.snapshots/TestRenderDeploymentJsonnet-deployments-appname-app.jsonnet.tpl-deployments-testing-testing.jsonnet.snapshot
+++ b/templates/.snapshots/TestRenderDeploymentJsonnet-deployments-appname-app.jsonnet.tpl-deployments-testing-testing.jsonnet.snapshot
@@ -136,6 +136,7 @@ local all = {
 					labels+: sharedLabels {
 					},
 					annotations+: {
+						configmap_hash: $.configmap.md5,
 						'iam.amazonaws.com/role': '%s_service_role' % app.name,
              datadog_prom_instances_:: [
 							{

--- a/templates/.snapshots/TestRenderDeploymentJsonnetWithHPA-deployments-appname-app.jsonnet.tpl-deployments-testing-testing.jsonnet.snapshot
+++ b/templates/.snapshots/TestRenderDeploymentJsonnetWithHPA-deployments-appname-app.jsonnet.tpl-deployments-testing-testing.jsonnet.snapshot
@@ -135,6 +135,7 @@ local all = {
 					labels+: sharedLabels {
 					},
 					annotations+: {
+						configmap_hash: $.configmap.md5,
 						'iam.amazonaws.com/role': '%s_service_role' % app.name,
              datadog_prom_instances_:: [
 							{

--- a/templates/.snapshots/TestRenderDeploymentJsonnet_Canary-deployments-appname-app.jsonnet.tpl-deployments-testing-testing.jsonnet.snapshot
+++ b/templates/.snapshots/TestRenderDeploymentJsonnet_Canary-deployments-appname-app.jsonnet.tpl-deployments-testing-testing.jsonnet.snapshot
@@ -172,6 +172,7 @@ local all = {
 						'tollgate.outreach.io/scrape': 'true',
 					},
 					annotations+: {
+						configmap_hash: $.configmap.md5,
 						'tollgate.outreach.io/group': app.name,
 						'tollgate.outreach.io/port': '5000',
 						'iam.amazonaws.com/role': '%s_service_role' % app.name,

--- a/templates/.snapshots/TestRenderDeploymentJsonnet_Canary_emptyServiceActivities-deployments-appname-app.jsonnet.tpl-deployments-testing-testing.jsonnet.snapshot
+++ b/templates/.snapshots/TestRenderDeploymentJsonnet_Canary_emptyServiceActivities-deployments-appname-app.jsonnet.tpl-deployments-testing-testing.jsonnet.snapshot
@@ -143,6 +143,7 @@ local all = {
 					labels+: sharedLabels {
 					},
 					annotations+: {
+						configmap_hash: $.configmap.md5,
 						'iam.amazonaws.com/role': '%s_service_role' % app.name,
              datadog_prom_instances_:: [
 							{

--- a/templates/deployments/appname/app.jsonnet.tpl
+++ b/templates/deployments/appname/app.jsonnet.tpl
@@ -209,6 +209,7 @@ local all = {
 					},
 					{{- end }}
 					annotations+: {
+						configmap_hash: $.configmap.md5,
 						{{- if (has "grpc" (stencil.Arg "serviceActivities")) }}
 						'tollgate.outreach.io/group': app.name,
 						'tollgate.outreach.io/port': '5000',


### PR DESCRIPTION
<!--
  !!!! README !!!! Please fill this out.

  Please follow the PR naming conventions: 
  https://outreach-io.atlassian.net/wiki/spaces/EN/pages/1902444645/Conventional+Commits
-->


<!-- A short description of what your PR does and what it solves. -->
## What this PR does / why we need it
Adds an annotation to each pod created by the deployment that's an md5 of the configmap so that if a configmap gets updated by the template it'll cause the pods to cycle and load the updated configmap.


<!-- <<Stencil::Block(jiraPrefix)>> -->

## Jira ID

[DT-3861]

<!-- <</Stencil::Block>> -->

<!-- Notes that may be helpful for anyone reviewing this PR -->
## Notes for your reviewers



<!-- <<Stencil::Block(custom)>> -->

<!-- <</Stencil::Block>> -->


[DT-3861]: https://outreach-io.atlassian.net/browse/DT-3861?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ