### PR TITLE
feat: support coralogix

### DIFF
--- a/templates/.snapshots/TestCoralogixTf-monitoring-coralogix.tf.tpl-monitoring-coralogix.tf.snapshot
+++ b/templates/.snapshots/TestCoralogixTf-monitoring-coralogix.tf.tpl-monitoring-coralogix.tf.snapshot
@@ -1,0 +1,12 @@
+(*codegen.File)(# Navigate to https://outreach.app.cx138.coralogix.com/#/webhooks, click on
+# your PD webhook, the URL will update and indicate the ID to use when setting
+# these variables
+variable "CoralogixPD_P1_notify" {
+  type    = number
+  default = 0
+}
+variable "CoralogixPD_P2_notify" {
+  type    = number
+  default = 0
+}
+)

--- a/templates/main_test.go
+++ b/templates/main_test.go
@@ -239,6 +239,23 @@ func TestDatadogTf_Override(t *testing.T) {
 	st.Run(true)
 }
 
+func TestCoralogixTf(t *testing.T) {
+	st := stenciltest.New(t, "monitoring/coralogix.tf.tpl", libaryTmpls...)
+	st.Args(map[string]interface{}{
+		"reportingTeam": "test:team",
+		"deployment": map[string]interface{}{
+			"environments": []interface{}{
+				"staging",
+				"production",
+			},
+			"serviceDomains": []interface{}{
+				"bento",
+			},
+		},
+	})
+	st.Run(true)
+}
+
 func TestGRPCTf(t *testing.T) {
 	st := stenciltest.New(t, "monitoring/grpc.tf.tpl", libaryTmpls...)
 	st.Args(map[string]interface{}{

--- a/templates/monitoring/coralogix.tf.tpl
+++ b/templates/monitoring/coralogix.tf.tpl
@@ -1,0 +1,12 @@
+{{- $_ := stencil.ApplyTemplate "skipIfNotService" -}}
+# Navigate to https://outreach.app.cx138.coralogix.com/#/webhooks, click on
+# your PD webhook, the URL will update and indicate the ID to use when setting
+# these variables
+variable "CoralogixPD_P1_notify" {
+  type    = number
+  default = 0
+}
+variable "CoralogixPD_P2_notify" {
+  type    = number
+  default = 0
+}

--- a/templates/monitoring/main.tf.tpl
+++ b/templates/monitoring/main.tf.tpl
@@ -20,7 +20,16 @@ data "vault_generic_secret" "datadog" {
   path = "deploy/datadog/alerting"
 }
 
+data "vault_generic_secret" "coralogix" {
+  path = "deploy/coralogix/alerting"
+}
+
 provider "datadog" {
   api_key = data.vault_generic_secret.datadog.data["api_key"]
   app_key = data.vault_generic_secret.datadog.data["app_key"]
+}
+
+provider "coralogix" {
+  api_key = data.vault_generic_secret.coralogix.data["api_key"]
+  domain  = "cx138.coralogix.com"
 }

--- a/templates/monitoring/versions.tf.tpl
+++ b/templates/monitoring/versions.tf.tpl
@@ -11,6 +11,10 @@ terraform {
       source = "hashicorp/vault"
       version = ">= 2.15.0"
     }
+    coralogix = {
+      version = ">= 1.6.6"
+      source  = "coralogix/coralogix"
+    }
   }
   required_version = ">= 0.13"
 }


### PR DESCRIPTION
Adds initial support for leveraging the coralogix terraform.
- coralogix api key was added at the listed vault path

A working plan leveraging these changes can be seen here: https://github.com/getoutreach/orgservice/pull/782#issuecomment-1675474276
I also tested by applying the plan locally, and subsequently destroying
it as to keep a clean tfstate.
