### PR TITLE
feat(grpcClients): move to Ruby 3

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -2,7 +2,7 @@
 # syntax, such as anchors, will be fixed automatically.
 version: 2.1
 orbs:
-  shared: getoutreach/shared@2.17.0
+  shared: getoutreach/shared@2.18.0
   queue: eddiewebb/queue@1.8.4
 
 parameters:
@@ -16,7 +16,6 @@ contexts: &contexts
   - ghaccesstoken
   - docker-registry
   - npm-credentials
-  - prismacloud-credentials
   - vault-dev
   - confluence
   - circleci-credentials

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -8,6 +8,7 @@ updates:
     # stencil-golang managed dependencies
     ignore:
       - dependency-name: github.com/getoutreach/gobox
+      - dependency-name: github.com/getoutreach/stencil-golang/pkg
       - dependency-name: github.com/getoutreach/stencil
 
   # Ignore semantic-release, this code is only executed in CI.

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -2,7 +2,7 @@
   // Please consider contributing back all added
   // settings to stencil!
   // <<Stencil::Block(settings)>>
-
+  "githubPullRequests.ignoredPullRequestBranches": ["main"],
   // <</Stencil::Block>>
   "go.lintTool": "golangci-lint",
   "go.lintFlags": [],
@@ -39,6 +39,5 @@
   },
   "protoc": {
     "options": ["--proto_path=${workspaceRoot}/api"]
-  },
-  "githubPullRequests.ignoredPullRequestBranches": ["main"]
+  }
 }

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -39,5 +39,6 @@
   },
   "protoc": {
     "options": ["--proto_path=${workspaceRoot}/api"]
-  }
+  },
+  "githubPullRequests.ignoredPullRequestBranches": ["main"]
 }

--- a/manifest.yaml
+++ b/manifest.yaml
@@ -179,7 +179,7 @@ arguments:
         - number
   versions.grpcClients.ruby:
     description: Ruby version to use for gRPC clients
-    default: "2.7.5"
+    default: "3.1.3"
     schema:
       type:
         - string


### PR DESCRIPTION
Now that Outreach's.. special service... has moved to Ruby 3, we can
move grpcClients to use that by default. So, here we are. Ruby 3. Wow!

Also a misc change to ignore PRs to `main` in VSCode, since those are
created during the release process and then closed.
