### PR TITLE
chore(vscode): syntax highlight Go templates

### DIFF
--- a/.vscode/extensions.json
+++ b/.vscode/extensions.json
@@ -9,12 +9,12 @@
     "zxh404.vscode-proto3",
     "redhat.vscode-yaml",
     "ms-azuretools.vscode-docker",
-    "foxundermoon.shell-format"
+    "foxundermoon.shell-format",
 
     // Please consider contributing back all recommended
     // extensions to stencil!
     // <<Stencil::Block(extensions)>>
-
+    "casualjim.gotemplate"
     // <</Stencil::Block>>
   ]
 }


### PR DESCRIPTION
## What this PR does / why we need it

Does what it says on the tin by adding a recommended VSCode extension.