### PR TITLE
fix(node): upgrade build nodejs version

### DIFF
--- a/manifest.yaml
+++ b/manifest.yaml
@@ -165,7 +165,7 @@ arguments:
         - number
   versions.nodejs:
     description: Nodejs version to use for build tooling (e.g., semantic-release)
-    default: "18.14.1"
+    default: "18.17.1"
     schema:
       type:
         - string


### PR DESCRIPTION
Updates then nodejs version used by build tooling
to be v18.17. This is NOT used for gRPC generation.
