### PR TITLE
fix(grpcClients): add ruby to root .tool-versions if enabled

### DIFF
--- a/monitoring/slos.tf
+++ b/monitoring/slos.tf
@@ -1,5 +1,0 @@
-
-
-// <<Stencil::Block(tfCustomSLODatadog)>>
-
-// <</Stencil::Block>>

--- a/templates/.snapshots/TestDontIncludeRubyToolVersionsIfNotRubyGRPCCLient-testdata-tool-versions-ruby-.tool-versions.tpl-testdata-tool-versions-ruby-.tool-versions.snapshot
+++ b/templates/.snapshots/TestDontIncludeRubyToolVersionsIfNotRubyGRPCCLient-testdata-tool-versions-ruby-.tool-versions.tpl-testdata-tool-versions-ruby-.tool-versions.snapshot
@@ -1,0 +1,11 @@
+(*codegen.File)(
+
+- name: golang
+  version: '1.20.7'
+# Not used for gRPC clients
+- name: nodejs
+  version: 18.14.1
+# Used in CI
+- name: protoc
+  version: 21.5
+)

--- a/templates/.snapshots/TestIncludeRubyToolVersionsIfRubyGRPCCLient-testdata-tool-versions-ruby-.tool-versions.tpl-testdata-tool-versions-ruby-.tool-versions.snapshot
+++ b/templates/.snapshots/TestIncludeRubyToolVersionsIfRubyGRPCCLient-testdata-tool-versions-ruby-.tool-versions.tpl-testdata-tool-versions-ruby-.tool-versions.snapshot
@@ -1,0 +1,13 @@
+(*codegen.File)(
+
+- name: golang
+  version: '1.20.7'
+# Not used for gRPC clients
+- name: nodejs
+  version: 18.14.1
+# Used in CI
+- name: protoc
+  version: 21.5
+- name: ruby
+  version: 3.1.3
+)

--- a/templates/_helpers.tpl
+++ b/templates/_helpers.tpl
@@ -19,6 +19,10 @@
 # Used in CI
 - name: protoc
   version: 21.5
+{{- if has "ruby" (stencil.Arg "grpcClients") }}
+- name: ruby
+  version: {{ stencil.Arg "versions.grpcClients.ruby" }}
+{{- end }}
 {{- end }}
 
 # Registers our versions w/ stencil-base

--- a/templates/api/clients/ruby/.tool-versions.tpl
+++ b/templates/api/clients/ruby/.tool-versions.tpl
@@ -1,8 +1,1 @@
-# Contains asdf versions for a ruby gRPC client.
-{{- $_ := stencil.ApplyTemplate "skipGrpcClient" "ruby" }}
-ruby {{ stencil.Arg "versions.grpcClients.ruby" }}
-## <<Stencil::Block(rubyToolVersions)>>
-{{- if file.Block "rubyToolVersions" }}
-{{ file.Block "rubyToolVersions" | stencil.Render "ruby" }}
-{{- end }}
-## <</Stencil::Block>>
+{{- file.Delete }}

--- a/templates/main_test.go
+++ b/templates/main_test.go
@@ -210,3 +210,17 @@ func TestVSCodeLaunchConfig(t *testing.T) {
 	})
 	st.Run(true)
 }
+
+func TestIncludeRubyToolVersionsIfRubyGRPCCLient(t *testing.T) {
+	st := stenciltest.New(t, "testdata/tool-versions-ruby/.tool-versions.tpl", libaryTmpls...)
+	st.Args(map[string]interface{}{
+		"grpcClients": []interface{}{"ruby"},
+	})
+	st.Run(true)
+}
+
+func TestDontIncludeRubyToolVersionsIfNotRubyGRPCCLient(t *testing.T) {
+	st := stenciltest.New(t, "testdata/tool-versions-ruby/.tool-versions.tpl", libaryTmpls...)
+	st.Args(map[string]interface{}{})
+	st.Run(true)
+}

--- a/templates/testdata/tool-versions-ruby/.tool-versions.tpl
+++ b/templates/testdata/tool-versions-ruby/.tool-versions.tpl
@@ -1,0 +1,2 @@
+{{- $_ := file.Skip "Test file" }}
+{{ stencil.ApplyTemplate "toolVersions" }}


### PR DESCRIPTION
Fixes `ruby` availability to be available to the entire repository if
the `ruby` grpc client is enabled. This fixes an issue where devbase
would skip configuring bundle authentication if `bundle` isn't available
in the root of the repo.

I hacked in tests by making a `testdata` folder containing a template
used to determine if we successfully included ruby or not based on the
specified arguments. This doesn't output to disk, thanks to the
`file.Skip` but is still able to be handled as a snapshot for testing.
Eventually, the new stencil testing framework will support this better.

**JIRA**: [DT-3995]


[DT-3995]: https://outreach-io.atlassian.net/browse/DT-3995?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ