### PR TITLE
fix: don't swallow panics

### DIFF
--- a/templates/cmd/main.go.tpl
+++ b/templates/cmd/main.go.tpl
@@ -73,7 +73,7 @@ func main() { //nolint: funlen // Why: We can't dwindle this down anymore withou
   exitCode := 1
 	defer func() {
 		if r := recover(); r != nil {
-			fmt.Fprintf(os.Stderr, "Recovered from panic: %+v\n%s\n", r, string(debug.Stack()))
+			panic(r)
 		}
 		os.Exit(exitCode)
 	}()

--- a/templates/cmd/main.go.tpl
+++ b/templates/cmd/main.go.tpl
@@ -72,6 +72,9 @@ type dependencies struct{
 func main() { //nolint: funlen // Why: We can't dwindle this down anymore without adding complexity.
   exitCode := 1
 	defer func() {
+		if r := recover(); r != nil {
+			fmt.Fprintf(os.Stderr, "Recovered from panic: %+v\n%s\n", r, string(debug.Stack()))
+		}
 		os.Exit(exitCode)
 	}()
 


### PR DESCRIPTION
<!-- A short description of what your PR does and what it solves. -->
## What this PR does / why we need it

In https://github.com/getoutreach/stencil-golang/pull/121/files a change was made to force exit the code while leaving main(), which was also executed when a panic was being thrown, swallowing and "hiding" it.

This change will at least print it to stderr for debugging.

Not sure whether we should instead make a formatted log entry but this is how panics used to be surfaced before.

<!-- <<Stencil::Block(jiraPrefix)>> -->

## Jira ID

[XX-XX]

<!-- <</Stencil::Block>> -->

<!-- Notes that may be helpful for anyone reviewing this PR -->
## Notes for your reviewers

TESTED=not tested

<!-- <<Stencil::Block(custom)>> -->

<!-- <</Stencil::Block>> -->
