### PR TITLE
test: update tool-versions snapshots

### DIFF
--- a/templates/.snapshots/TestDontIncludeRubyToolVersionsIfNotRubyGRPCCLient-testdata-tool-versions-ruby-.tool-versions.tpl-testdata-tool-versions-ruby-.tool-versions.snapshot
+++ b/templates/.snapshots/TestDontIncludeRubyToolVersionsIfNotRubyGRPCCLient-testdata-tool-versions-ruby-.tool-versions.tpl-testdata-tool-versions-ruby-.tool-versions.snapshot
@@ -4,7 +4,7 @@
   version: '1.20.7'
 # Not used for gRPC clients
 - name: nodejs
-  version: 18.14.1
+  version: 18.17.1
 # Used in CI
 - name: protoc
   version: 21.5

--- a/templates/.snapshots/TestIncludeRubyToolVersionsIfRubyGRPCCLient-testdata-tool-versions-ruby-.tool-versions.tpl-testdata-tool-versions-ruby-.tool-versions.snapshot
+++ b/templates/.snapshots/TestIncludeRubyToolVersionsIfRubyGRPCCLient-testdata-tool-versions-ruby-.tool-versions.tpl-testdata-tool-versions-ruby-.tool-versions.snapshot
@@ -4,7 +4,7 @@
   version: '1.20.7'
 # Not used for gRPC clients
 - name: nodejs
-  version: 18.14.1
+  version: 18.17.1
 # Used in CI
 - name: protoc
   version: 21.5


### PR DESCRIPTION
## What this PR does / why we need it

Follow-up to #361, fixes the CI failure.