### PR TITLE
fix(vscode): use correct to path for GOMODCACHE

### DIFF
--- a/templates/.snapshots/TestVSCodeLaunchConfig-.vscode-launch.json.tpl-.vscode-launch.json.snapshot
+++ b/templates/.snapshots/TestVSCodeLaunchConfig-.vscode-launch.json.tpl-.vscode-launch.json.snapshot
@@ -36,10 +36,10 @@
           "to": "/home/dev/app"
         },
         // Maps the go module cache on the host to the persistent volume used by devspaces.
-        // See the value of `go env GOMODCACHE` on the host and devspace.
+        // These should be the respective values of `go env GOMODCACHE`.
         {
           "from": "${env:HOME}/.asdf/installs/golang/1.20.8/packages/pkg/mod",
-          "to": "/tmp/cache/go/mod/"
+          "to": "/home/dev/.asdf/installs/golang/1.20.8/packages/pkg/mod"
         },
         {
           // Maps the standard library location on the host to the location in the devspace.

--- a/templates/.vscode/launch.json.tpl
+++ b/templates/.vscode/launch.json.tpl
@@ -41,10 +41,10 @@
           "to": "/home/dev/app"
         },
         // Maps the go module cache on the host to the persistent volume used by devspaces.
-        // See the value of `go env GOMODCACHE` on the host and devspace.
+        // These should be the respective values of `go env GOMODCACHE`.
         {
           "from": "${env:HOME}/.asdf/installs/golang/{{ $goVersion }}/packages/pkg/mod",
-          "to": "/tmp/cache/go/mod/"
+          "to": "/home/dev/.asdf/installs/golang/{{ $goVersion }}/packages/pkg/mod"
         },
         {
           // Maps the standard library location on the host to the location in the devspace.


### PR DESCRIPTION
Updates the path used for mapping from the host to a path in the
devspace pod. This was changed a few PRs ago to use the same paths as
the host (minus `$HOME` prefix) for simplicity, but this path wasn't
updated.
