### PR TITLE
feat: upgrade to yarn v4

### DIFF
--- a/templates/api/clients/node/.yarnrc.yml.tpl
+++ b/templates/api/clients/node/.yarnrc.yml.tpl
@@ -1,0 +1,4 @@
+compressionLevel: mixed
+enableGlobalCache: true
+globalFolder: "${HOME}/.cache/yarn/berry/global"
+nodeLinker: pnpm

--- a/templates/api/clients/node/package.hjson.tpl
+++ b/templates/api/clients/node/package.hjson.tpl
@@ -3,8 +3,8 @@
   // This file is not automatically turned into package.json
   // In order to do so, run: `make gogenerate` in the root
   // of this repository.
-
   "name": "@getoutreach/{{ .Config.Name }}-client",
+  "packageManager": "yarn@4.0.1",
   "version": "0.0.1",
   "description": "{{ .Config.Name }} client implementation",
   "main": "dist/index.js",


### PR DESCRIPTION
Upgrades the node client to use `yarn` v3. Depends on the following PRs:

* https://github.com/getoutreach/devbase/pull/666
* https://github.com/getoutreach/stencil-base/pull/139
