### PR TITLE
fix(grpc): upgrade Node.js version to 18

### DIFF
--- a/manifest.yaml
+++ b/manifest.yaml
@@ -172,7 +172,7 @@ arguments:
         - number
   versions.grpcClients.nodejs:
     description: Nodejs version to use for gRPC clients
-    default: "16.19.0"
+    default: "18.17.1"
     schema:
       type:
         - string


### PR DESCRIPTION
## What this PR does / why we need it

Node.js 16 is EOL as of 2023-09-11 (per the [Node.js Release working group](https://github.com/nodejs/Release)).