### PR TITLE
fix: allow linter on semi-generated gql resolvers

### DIFF
--- a/templates/scripts/golangci.yml.tpl
+++ b/templates/scripts/golangci.yml.tpl
@@ -124,6 +124,12 @@ issues:
     - linters:
         - lll
       source: "^//go:generate "
+    # gqlgen-generated function header
+    - path: \.resolvers\.go
+      source: "^func \\(r \\*[a-zA-Z]+Resolvers\\) "
+      linters:
+        - lll
+        - gocritic
 
 output:
   format: colored-line-number

--- a/templates/scripts/golangci.yml.tpl
+++ b/templates/scripts/golangci.yml.tpl
@@ -124,12 +124,10 @@ issues:
     - linters:
         - lll
       source: "^//go:generate "
-    # gqlgen-generated function header
-    - path: \.resolvers\.go
-      source: "^func \\(r \\*[a-zA-Z]+Resolvers\\) "
-      linters:
-        - lll
-        - gocritic
+{{- $hook := (stencil.GetModuleHook "golangci-lint/exclude-rules") }}
+{{- if $hook }}
+{{ toYaml $hook | indent 4 }}
+{{- end }}
 
 output:
   format: colored-line-number


### PR DESCRIPTION
<!--
  !!!! README !!!! Please fill this out.

  Please follow conventional commit naming conventions:

  https://www.conventionalcommits.org/en/v1.0.0/#summary
-->

Please read [CONTRIBUTING.md](CONTRIBUTING.md) for additional information on contributing to this repository!

<!-- A short description of what your PR does and what it solves. -->
## What this PR does / why we need it

There is a formatter for generated resolvers introduced in [another PR](https://github.com/getoutreach/stencil-graphql/pull/152) that removes most of the issues linter would complaint about semi-generated GraphQL resolvers. The last problem is the line length and not combined parameters of resolver methods. Formatting would be non-trivial, so for now we can just add ignore rule in scripts/golangci.yml.


<!-- <<Stencil::Block(jiraPrefix)>> -->

## Jira ID

[XX-XX]

<!-- <</Stencil::Block>> -->

<!-- Notes that may be helpful for anyone reviewing this PR -->
## Notes for your reviewers

<!-- <<Stencil::Block(custom)>> -->

<!-- <</Stencil::Block>> -->
