### PR TITLE
fix: use @getoutreach for gRPC client scope

### DIFF
--- a/templates/api/clients/node/package.hjson.tpl
+++ b/templates/api/clients/node/package.hjson.tpl
@@ -4,7 +4,7 @@
   // In order to do so, run: `make gogenerate` in the root
   // of this repository.
 
-  "name": "@outreach/{{ .Config.Name }}-client",
+  "name": "@getoutreach/{{ .Config.Name }}-client",
   "version": "0.0.1",
   "description": "{{ .Config.Name }} client implementation",
   "main": "dist/index.js",


### PR DESCRIPTION
Updates the scope of the generated gRPC client to be `@getoutreach`
which is exclusively published to Github Packages.

[DT-4053]


[DT-4053]: https://outreach-io.atlassian.net/browse/DT-4053?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ