### PR TITLE
fix: Add a 'team' tag to the main Datadog dashboard

### DIFF
--- a/templates/monitoring/dashboard.tf.tpl
+++ b/templates/monitoring/dashboard.tf.tpl
@@ -373,6 +373,7 @@ module "temporaldashboard_otel" {
   source      = "git@github.com:getoutreach/monitoring-terraform.git//modules/dd-dashboards"
   name        = "Terraform: {{ .Config.Name | title }} Temporal OTEL"
   description = "Managed by terraform in github.com/getoutreach/{{ .Config.Name }}"
+  tags        = ["team:{{ stencil.Arg "reportingTeam" }}"]
 
   parameters = local.dashboard_parameters
   sections = [


### PR DESCRIPTION
<!--
  !!!! README !!!! Please fill this out.

  Please follow conventional commit naming conventions:

  https://www.conventionalcommits.org/en/v1.0.0/#summary
-->


<!-- A short description of what your PR does and what it solves. -->
## What this PR does / why we need it

Right now we don't tag the main `Terraform: {servicename}` datadog dashboard with the team that owns the service, even though we do add a link to that team in the description of the service.

Since we're planning to use "does the dashboard have a team" as a metric for whether or not to clean up that dashboard, these Terraform dashboards (which we use a lot) should have the team added.


<!-- <<Stencil::Block(jiraPrefix)>> -->

## Jira ID

There's no Jira for this; I saw that this is missing and I'm fixing it now.

<!-- <</Stencil::Block>> -->

<!-- Notes that may be helpful for anyone reviewing this PR -->
## Notes for your reviewers

<!-- <<Stencil::Block(custom)>> -->

<!-- <</Stencil::Block>> -->
