### PR TITLE
fix(nodeGRPCClient): missed some scope updates

### DIFF
--- a/templates/api/clients/node/.eslintrc.js.tpl
+++ b/templates/api/clients/node/.eslintrc.js.tpl
@@ -1,6 +1,6 @@
 {{- $_ := stencil.ApplyTemplate "skipGrpcClient" "node" }}
 module.exports = {
-  extends: ['@outreach/eslint-config/node', 'plugin:jsdoc/recommended'],
+  extends: ['@getoutreach/eslint-config/node', 'plugin:jsdoc/recommended'],
   plugins: ['jsdoc', '@typescript-eslint'],
   ignorePatterns: ['*.d.ts', 'publish.js'],
   rules: {

--- a/templates/api/clients/node/README.md.tpl
+++ b/templates/api/clients/node/README.md.tpl
@@ -1,5 +1,5 @@
 {{- $_ := stencil.ApplyTemplate "skipGrpcClient" "node" -}}
-# `@outreach/{{ .Config.Name }}-client`
+# `@getoutreach/{{ .Config.Name }}-client`
 
 This is a Node.js gRPC client for the `{{ .Config.Name }}` service.
 

--- a/templates/api/clients/node/jest.config.js.tpl
+++ b/templates/api/clients/node/jest.config.js.tpl
@@ -4,7 +4,7 @@ module.exports = {
   collectCoverageFrom: ['**/src/**'],
   coveragePathIgnorePatterns: ['<rootDir>/src/grpc/'],
   moduleNameMapper: {
-    ['@outreach/{{ .Config.Name }}-client']: '<rootDir>/src'
+    ['@getoutreach/{{ .Config.Name }}-client']: '<rootDir>/src'
   },
   modulePathIgnorePatterns: ['dist', '\\.(json)$'],
   preset: 'ts-jest',

--- a/templates/api/clients/node/scripts/copy-definitions.js.tpl
+++ b/templates/api/clients/node/scripts/copy-definitions.js.tpl
@@ -1,5 +1,5 @@
 {{- $_ := stencil.ApplyTemplate "skipGrpcClient" "node" -}}
-const { build } = require('@outreach/grpc-client');
+const { build } = require('@getoutreach/grpc-client');
 const path = require('path');
 
 build.copyDefinitions(path.resolve(__dirname, '..'));

--- a/templates/api/clients/node/src/client-helpers.ts.tpl
+++ b/templates/api/clients/node/src/client-helpers.ts.tpl
@@ -1,9 +1,9 @@
 {{- $_ := stencil.ApplyTemplate "skipGrpcClient" "node" -}}
 import * as grpc from '@grpc/grpc-js';
 import { {{ stencil.ApplyTemplate "serviceNameLanguageSafe" }}Client } from './grpc/{{ .Config.Name }}_grpc_pb';
-import { createErrorLoggerInterceptor } from '@outreach/grpc-client';
+import { createErrorLoggerInterceptor } from '@getoutreach/grpc-client';
 import winston from 'winston';
-import * as find from '@outreach/find';
+import * as find from '@getoutreach/find';
 
 const level = 'error';
 const ConsoleTransport = () => {

--- a/templates/api/clients/node/tsconfig.json.tpl
+++ b/templates/api/clients/node/tsconfig.json.tpl
@@ -16,7 +16,7 @@
     "emitDecoratorMetadata": true,
     "allowJs": true,
     "paths": {
-      "@outreach/{{ .Config.Name }}-client": ["src"]
+      "@getoutreach/{{ .Config.Name }}-client": ["src"]
     },
     "lib": ["es2018", "es2018.promise", "esnext.asynciterable", "dom"]
   },


### PR DESCRIPTION
There were a few `@outreach` scope changes that were missed. This
updates them to be `@getoutreach`.

[DT-4053]


[DT-4053]: https://outreach-io.atlassian.net/browse/DT-4053?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ