### PR TITLE
feat(node): upgrade to v20

### DIFF
--- a/manifest.yaml
+++ b/manifest.yaml
@@ -168,14 +168,14 @@ arguments:
         - number
   versions.nodejs:
     description: Nodejs version to use for build tooling (e.g., semantic-release)
-    default: "18.17.1"
+    default: "20.9.0"
     schema:
       type:
         - string
         - number
   versions.grpcClients.nodejs:
     description: Nodejs version to use for gRPC clients
-    default: "20.8.0"
+    default: "20.9.0"
     schema:
       type:
         - string


### PR DESCRIPTION
`20` is now LTS, and since we use it for node clients, we will also use
it for build tooling.
