### PR TITLE
fix(node): upgrade grpc-tools

### DIFF
--- a/bootstrap.lock
+++ b/bootstrap.lock
@@ -1,4 +1,0 @@
-versions:
-  # HACK(jaredallard): Remove when stencil-base is cleaned up and bootstrap
-  # is dead.
-  devbase: v2.4.0-rc.5

--- a/templates/_helpers.tpl
+++ b/templates/_helpers.tpl
@@ -195,7 +195,7 @@ nodejs:
   - name: eslint-plugin-node
     version: ^11.1.0
   - name: grpc-tools
-    version: ^1.9.1
+    version: ^1.12.4
   - name: grpc_tools_node_protoc_ts
     version: ^5.0.1
   - name: jest


### PR DESCRIPTION
Upgrades `grpc-tools` to fix issues with M1 Macs and node 20 binaries.
