### PR TITLE
fix: Prevent build failures by limiting type scope

### DIFF
--- a/templates/api/clients/node/tsconfig.json.tpl
+++ b/templates/api/clients/node/tsconfig.json.tpl
@@ -18,6 +18,12 @@
     "paths": {
       "@getoutreach/{{ .Config.Name }}-client": ["src"]
     },
+    {{- /* This 'typeroots' is required to be here to prevent tsc from including conflicting types
+    from BOTH node_modules/ and ../../../node_modules/ (in the root of the generated service). This
+    line prevents the default tsc behavior (a terrible default, ugh) by limiting typescript types to
+    only those found in the api/clients/nodes/node_modules/@types/ folder and nowhere else.
+    */ -}}
+    "typeRoots": ["node_modules/@types"],
     "lib": ["es2018", "es2018.promise", "esnext.asynciterable", "dom"]
   },
   "include": ["src/**/*.ts", "src/**/*.js"],


### PR DESCRIPTION
<!--
  !!!! README !!!! Please fill this out.

  Please follow conventional commit naming conventions:

  https://www.conventionalcommits.org/en/v1.0.0/#summary
-->


<!-- A short description of what your PR does and what it solves. -->
## What this PR does / why we need it

This change prevents potential build failures by telling the typescript compiler not to include types from parent node modules, which it does by default (which is terrible default behavior that we have to compensate for, ugh).

Docs on the subject: https://www.typescriptlang.org/tsconfig#typeRoots

Relevant quote:

> By default all visible "`@types`" packages are included in your compilation. Packages in `node_modules/@types` of any enclosing folder are considered visible. For example, that means packages within `./node_modules/@types/`, `../node_modules/@types/`, `../../node_modules/@types/`, and so on.

Without this change we were seeing `yarn build` fail because `tsc` run in `api/clients/node/` wouldn't limit it's type definitions to those in `api/clients/node/node_modules`, it'd also include conflicting type definitions from the root `node_modules/`.


<!-- <<Stencil::Block(jiraPrefix)>> -->

## Jira ID

No jira, this was identified and fixed based on a pressing production need.

<!-- <</Stencil::Block>> -->

<!-- Notes that may be helpful for anyone reviewing this PR -->
## Notes for your reviewers

<!-- <<Stencil::Block(custom)>> -->

<!-- <</Stencil::Block>> -->
