### PR TITLE
fix(rubyClient): upgrade dependencies, unmanage Gemfile.lock

### DIFF
--- a/templates/api/clients/ruby/Gemfile.lock.tpl
+++ b/templates/api/clients/ruby/Gemfile.lock.tpl
@@ -1,27 +1,29 @@
 {{- $_ := stencil.ApplyTemplate "skipGrpcClient" "ruby" -}}
+{{ file.Static }}
 PATH
   remote: .
   specs:
-    {{ .Config.Name }}_client (1.63.0)
-      grpc (~> 1.38)
+    {{ .Config.Name }}_client (0.0.0)
+      grpc (~> 1.59)
 
 GEM
   remote: https://rubygems.org/
   specs:
-    google-protobuf (3.19.1)
-    googleapis-common-protos-types (1.3.0)
-      google-protobuf (~> 3.14)
-    grpc (1.42.0)
+    google-protobuf (3.25.0)
+    google-protobuf (3.25.0-arm64-darwin)
+    googleapis-common-protos-types (1.10.0)
       google-protobuf (~> 3.18)
+    grpc (1.59.2)
+      google-protobuf (~> 3.24)
       googleapis-common-protos-types (~> 1.0)
-    rake (13.0.6)
-
+    rake (13.1.0)
 PLATFORMS
   -darwin-20
+  arm64-darwin-22
 
 DEPENDENCIES
   {{ .Config.Name }}_client!
   rake
 
 BUNDLED WITH
-   2.2.29
+   2.3.26

--- a/templates/api/clients/ruby/client.gemspec.tpl
+++ b/templates/api/clients/ruby/client.gemspec.tpl
@@ -11,11 +11,11 @@ Gem::Specification.new do |spec|
   spec.metadata["source_code_uri"] = spec.homepage
   spec.metadata["github_repo"] = "ssh://github.com/getoutreach/{{ .Config.Name }}"
 
-  spec.required_ruby_version = Gem::Requirement.new(">= 2.7.5")
+  spec.required_ruby_version = Gem::Requirement.new(">= {{ stencil.Arg "versions.grpcClients.ruby" }}")
   spec.files         = Dir.chdir(File.expand_path('..', __FILE__)) do
     `git ls-files -z`.split("\x0").reject { |f| f.match(%r{^(test|spec|features)/}) }
   end
   spec.require_paths = ["lib", "lib/{{ .Config.Name }}_client"]
-  spec.add_dependency 'grpc', '~> 1.38'
+  spec.add_dependency 'grpc', '~> 1.59'
   spec.add_development_dependency 'rake'
 end


### PR DESCRIPTION
Updates the dependencies used by the ruby client. Makes `Gemfile.lock`
as static so that we no longer manage it.
