### PR TITLE
fix(manifest): depend on a non-RC version of devbase

### DIFF
--- a/manifest.yaml
+++ b/manifest.yaml
@@ -2,7 +2,7 @@ name: github.com/getoutreach/stencil-golang
 ## <<Stencil::Block(keys)>>
 modules:
   - name: github.com/getoutreach/devbase
-    version: ">=2.21.0-rc.1"
+    version: ">=2.21.0"
 type: templates,extension
 arguments:
   # The following terraform.datadog fields are used for Canary deployments in app.jsonnet.tpl


### PR DESCRIPTION
## What this PR does / why we need it

The current behavior of stencil is that if you put an RC version in the version field of a dependency module, it will require the RC channel, even after a non-RC version of that module has been released. So, update the minimum version to be a non-RC version.