### PR TITLE
chore: Hotfix 2ded2125b072bec9dffdfae07cc17e956b5f6450 into channel stable

### DIFF
--- a/manifest.yaml
+++ b/manifest.yaml
@@ -2,7 +2,7 @@ name: github.com/getoutreach/stencil-golang
 ## <<Stencil::Block(keys)>>
 modules:
   - name: github.com/getoutreach/devbase
-    version: ">=2.21.0-rc.1"
+    version: ">=2.21.0"
 type: templates,extension
 arguments:
   # The following terraform.datadog fields are used for Canary deployments in app.jsonnet.tpl


### PR DESCRIPTION
Hotfixes commit(s) "2ded2125b072bec9dffdfae07cc17e956b5f6450" into channel stable, created by `dt release hotfix`

**DO NOT MERGE**