### PR TITLE
fix(devspace): remove kubectl proxy command

### DIFF
--- a/templates/.snapshots/TestDevspaceYaml-devspace.yaml.tpl-devspace.yaml.snapshot
+++ b/templates/.snapshots/TestDevspaceYaml-devspace.yaml.tpl-devspace.yaml.snapshot
@@ -457,10 +457,6 @@ profiles:
             command: |-
               entrypoint
 
-          # enable kubectl inside of dev pod (some e2e tests need it)
-          proxyCommands:
-            - command: kubectl
-
   - name: Loft
     description: >
       Enables deploying to Loft.

--- a/templates/devspace.yaml.tpl
+++ b/templates/devspace.yaml.tpl
@@ -481,10 +481,6 @@ profiles:
             command: |-
               entrypoint
 
-          # enable kubectl inside of dev pod (some e2e tests need it)
-          proxyCommands:
-            - command: kubectl
-
   - name: Loft
     description: >
       Enables deploying to Loft.


### PR DESCRIPTION
## What this PR does / why we need it

This is causing issues in various places, and it's unclear if anyone's actually depending on this. We're open to reverting this if the removal affects users negatively.

## Jira ID

[DT-4124]

[DT-4124]: https://outreach-io.atlassian.net/browse/DT-4124?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ