### PR TITLE
fix: Makes sure binary sync profile copies migration dir

### DIFF
--- a/templates/.snapshots/TestDevspaceYaml-devspace.yaml.tpl-devspace.yaml.snapshot
+++ b/templates/.snapshots/TestDevspaceYaml-devspace.yaml.tpl-devspace.yaml.snapshot
@@ -433,12 +433,12 @@ profiles:
         path: vars.DEV_CONTAINER_IMAGE
         value: gcr.io/outreach-docker/bootstrap/dev-slim:stable
       - op: replace
-        path: dev.app.sync
+        path: dev.app.sync[0]
         value:
-          - path: ./bin:${DEV_CONTAINER_WORKDIR}
-            printLogs: true
-            disableDownload: true
-            waitInitialSync: true
+          path: ./bin:${DEV_CONTAINER_WORKDIR}
+          printLogs: true
+          disableDownload: true
+          waitInitialSync: true
       - op: add
         path: hooks
         value:

--- a/templates/devspace.yaml.tpl
+++ b/templates/devspace.yaml.tpl
@@ -457,12 +457,12 @@ profiles:
         path: vars.DEV_CONTAINER_IMAGE
         value: gcr.io/outreach-docker/bootstrap/dev-slim:stable
       - op: replace
-        path: dev.app.sync
+        path: dev.app.sync[0]
         value:
-          - path: ./bin:${DEV_CONTAINER_WORKDIR}
-            printLogs: true
-            disableDownload: true
-            waitInitialSync: true
+          path: ./bin:${DEV_CONTAINER_WORKDIR}
+          printLogs: true
+          disableDownload: true
+          waitInitialSync: true
       - op: add
         path: hooks
         value:


### PR DESCRIPTION
<!--
  !!!! README !!!! Please fill this out.

  Please follow conventional commit naming conventions:

  https://www.conventionalcommits.org/en/v1.0.0/#summary
-->

Please read [CONTRIBUTING.md](CONTRIBUTING.md) for additional information on contributing to this repository!

<!-- A short description of what your PR does and what it solves. -->
## What this PR does / why we need it

In binary sync profile, we were overwriting the entire 'sync' section, this prevented the copy of migration directories. This change ensures that we do copy this over as well. 
<!-- <<Stencil::Block(jiraPrefix)>> -->

## Jira ID

[XX-XX]

<!-- <</Stencil::Block>> -->

<!-- Notes that may be helpful for anyone reviewing this PR -->
## Notes for your reviewers

<!-- <<Stencil::Block(custom)>> -->

<!-- <</Stencil::Block>> -->
