### PR TITLE
fix(nodejs): do not run lint/format during client build

### DIFF
--- a/templates/api/clients/node/package.hjson.tpl
+++ b/templates/api/clients/node/package.hjson.tpl
@@ -36,7 +36,7 @@
     // <<Stencil::Block(nodeScripts)>>
 {{ file.Block "nodeScripts" }}
     // <</Stencil::Block>>
-    "build": "npm-run-all clean pretty lint tsc",
+    "build": "npm-run-all clean tsc",
     "ci": "npm-run-all pretty lint test-ci",
     "clean": "rimraf dist",
     "lint": "eslint src --ext .ts",


### PR DESCRIPTION
## What this PR does / why we need it

Linting and formatting should already have been run in the PR CI, it doesn't need to run when building for release.