### PR TITLE
fix(rpc): avoid lint error when there are no server options

### DIFF
--- a/templates/.snapshots/TestGRPCServerRPC-internal-appName-rpc-rpc.go.tpl-internal-testing-rpc.go.snapshot
+++ b/templates/.snapshots/TestGRPCServerRPC-internal-appName-rpc-rpc.go.tpl-internal-testing-rpc.go.snapshot
@@ -128,8 +128,8 @@ func (gs *GRPCService) StartServers(ctx context.Context, servers *Servers, opts.
 	// Register default server, title function won't work well when use underscore, so we make it dash first
 	api.RegisterTestingServer(s, rpcserver{servers.DefaultServer})
 
-  // Register your additional RPC servers here
- 	// <<Stencil::Block(registrations)>>
+	// Register your additional RPC servers here
+	// <<Stencil::Block(registrations)>>
 
 	// <</Stencil::Block>>
 

--- a/templates/.snapshots/TestGRPCServerRPC-internal-appName-rpc-rpc.go.tpl-internal-testing-rpc.go.snapshot
+++ b/templates/.snapshots/TestGRPCServerRPC-internal-appName-rpc-rpc.go.tpl-internal-testing-rpc.go.snapshot
@@ -1,49 +1,28 @@
-{{- if not (has "grpc" (stencil.Arg "serviceActivities")) }}
-{{ file.Skip "Not a gRPC service" }}
-{{- end }}
-{{- $_ := file.SetPath (printf "internal/%s/%s" .Config.Name (base file.Path)) }}
-{{- $pkgName := stencil.ApplyTemplate "goPackageSafeName" }}
-// {{ stencil.ApplyTemplate "copyright" }}
+(*codegen.File)(
+// Copyright 2024 Outreach Corporation. All Rights Reserved.
 
 // Description: This file contains the gRPC server passthrough implementation for the
-// {{ .Config.Name }} API defined in api/{{ .Config.Name }}.proto. The concrete implementation
+// testing API defined in api/testing.proto. The concrete implementation
 // exists in the server.go file in this same directory.
 // Managed: true
-{{- $extraComments := (stencil.GetModuleHook "internal/rpc/extraComments") }}
-{{- range $extraComments }}
-{{- .}}
-{{- end }}
 
-package {{ $pkgName }} //nolint:revive // Why: We allow [-_].
+package testing //nolint:revive // Why: We allow [-_].
 
 import (
 	"context"
 	"fmt"
 	"net"
-{{- $extraStandardImports := (stencil.GetModuleHook "internal/rpc/extraStandardImports") }}
-{{- range $extraStandardImports }}
-{{- .}}
-{{- end }}
 
 	"github.com/getoutreach/gobox/pkg/events"
 	"github.com/getoutreach/gobox/pkg/log"
 	"github.com/getoutreach/gobox/pkg/trace"
-	"github.com/getoutreach/{{ .Config.Name }}/api"
+	"github.com/getoutreach/testing/api"
 	"github.com/getoutreach/services/pkg/grpcx"
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/reflection"
 
-	{{- $additionalImports := stencil.GetModuleHook "internal/rpc/additionalImports" }}
-	{{- if $additionalImports }}
-	// imports added by modules
-		{{- range $additionalImports }}
-	{{ . | quote }}
-		{{- end }}
-	// end imports added by modules
-	{{- end }}
-
 	// <<Stencil::Block(imports)>>
-{{ file.Block "imports" }}
+
 	// <</Stencil::Block>>
 )
 
@@ -52,17 +31,8 @@ import (
 // connection or perhaps a redis client that the service activity needs to use.
 type GRPCDependencies struct{
     // <<Stencil::Block(GRPCDependencies)>>
-{{ file.Block "GRPCDependencies" }}
-	  // <</Stencil::Block>>
 
-    {{- $gRPCDependencyInjection := stencil.GetModuleHook "internal/rpc/gRPCDependencyInjection" }}
-    {{- if $gRPCDependencyInjection }}
-    // dependencies injected by modules
-    {{- range $gRPCDependencyInjection }}
-    {{ . }}
-    {{- end }}
-    // end dependencies injected by modules
-    {{- end }}
+	  // <</Stencil::Block>>
 }
 
 // GRPCService is the concrete implementation of the serviceActivity interface
@@ -86,7 +56,7 @@ type Servers struct {
   DefaultServer api.Service
   // Add your additional RPC servers here
   // <<Stencil::Block(servers)>>
-{{ file.Block "servers" }}
+
   // <</Stencil::Block>>
 }
 
@@ -108,15 +78,11 @@ func (gs *GRPCService) Run(ctx context.Context) error {
 		// Initialize your server instance here.
 		//
 		// <<Stencil::Block(server)>>
-	{{- if file.Block "server" }}
-{{ file.Block "server" }}
-	{{- else }}
 		server, err := NewServer(ctx, gs.cfg)
 		if err != nil {
 				log.Error(ctx, "failed to create new server", events.NewErrorInfo(err))
 				return err
 		}
-	{{- end }}
 		// <</Stencil::Block>>
     servers.DefaultServer = server
 
@@ -150,31 +116,8 @@ func (gs *GRPCService) Close(ctx context.Context) error {
 
 // StartServers starts a RPC server with the provided implementation.
 func (gs *GRPCService) StartServers(ctx context.Context, servers *Servers, opts... grpcx.ServerOption) (*grpc.Server, error) {
-	{{- $grpcServerOptionInit := stencil.GetModuleHook "internal/rpc/grpcServerOptionInit" }}
-	{{- if $grpcServerOptionInit }}
-	// gRPC server option initialization injected by modules
-		{{- range $grpcServerOptionInit }}
-	{{ . }}
-
-		{{- end }}
-	// end gRPC server option initialization injected by modules
-
-	{{- end }}
-  {{- $grpcServerOptions := stencil.GetModuleHook "internal/rpc/grpcServerOptions" }}
-  {{- if $grpcServerOptions }}
-	opts = append([]grpcx.ServerOption{
-		// gRPC server options injected by modules
-			{{- range $grpcServerOptions }}
-		{{ . }},
-			{{- end }}
-		// end gRPC server options injected by modules
-	}, opts...)
-  {{- end }}
-  {{- if or $grpcServerOptionInit $grpcServerOptions }}
-
-  {{- end }}
 	// <<Stencil::Block(grpcServerOptions)>>
-{{ file.Block "grpcServerOptions" }}
+
 	// <</Stencil::Block>>
 
 	s, err := grpcx.NewServer(ctx, opts...)
@@ -182,21 +125,12 @@ func (gs *GRPCService) StartServers(ctx context.Context, servers *Servers, opts.
 		return nil, err
 	}
 
-	{{- $additionalGRPCRPCS := stencil.GetModuleHook "internal/rpc/additionalGRPCRPCS" }}
-	{{- if $additionalGRPCRPCS }}
-	// gRPC RPCs injected by modules
-		{{- range $additionalGRPCRPCS }}
-	{{ . }}
-		{{- end }}
-	// end gRPC RPCs injected by modules
-	{{- end }}
-
 	// Register default server, title function won't work well when use underscore, so we make it dash first
-	api.Register{{ stencil.ApplyTemplate "goTitleCaseName" }}Server(s, rpcserver{servers.DefaultServer})
+	api.RegisterTestingServer(s, rpcserver{servers.DefaultServer})
 
   // Register your additional RPC servers here
  	// <<Stencil::Block(registrations)>>
-{{ file.Block "registrations" }}
+
 	// <</Stencil::Block>>
 
 	// Register reflection
@@ -214,9 +148,6 @@ type rpcserver struct {
 // Place any GRPC handler functions for your service here
 //
 // <<Stencil::Block(handlers)>>
-{{- if file.Block "handlers" }}
-{{ file.Block "handlers" }}
-{{- else }}
 
 // Ping is a simple ping/pong handler.
 func (s rpcserver) Ping(ctx context.Context, req *api.PingRequest) (*api.PingResponse, error) {
@@ -235,11 +166,5 @@ func (s rpcserver) Pong(ctx context.Context, req *api.PongRequest) (*api.PongRes
 	}
 	return &api.PongResponse{Message: message}, nil
 }
-
-{{- $additionalDefaultHandlers := stencil.GetModuleHook "internal/rpc/additionalDefaultHandlers" }}
-{{- range $additionalDefaultHandlers }}
-{{ . }}
-
-{{- end }}
-{{- end }}
 // <</Stencil::Block>>
+)

--- a/templates/internal/appName/rpc/rpc.go.tpl
+++ b/templates/internal/appName/rpc/rpc.go.tpl
@@ -194,8 +194,8 @@ func (gs *GRPCService) StartServers(ctx context.Context, servers *Servers, opts.
 	// Register default server, title function won't work well when use underscore, so we make it dash first
 	api.Register{{ stencil.ApplyTemplate "goTitleCaseName" }}Server(s, rpcserver{servers.DefaultServer})
 
-  // Register your additional RPC servers here
- 	// <<Stencil::Block(registrations)>>
+	// Register your additional RPC servers here
+	// <<Stencil::Block(registrations)>>
 {{ file.Block "registrations" }}
 	// <</Stencil::Block>>
 

--- a/templates/main_test.go
+++ b/templates/main_test.go
@@ -211,6 +211,17 @@ func TestVSCodeLaunchConfig(t *testing.T) {
 	st.Run(true)
 }
 
+func TestGRPCServerRPC(t *testing.T) {
+	st := stenciltest.New(t, "internal/appName/rpc/rpc.go.tpl", libraryTmpls...)
+	st.Args(map[string]interface{}{
+		"service": true,
+		"serviceActivities": []interface{}{
+			"grpc",
+		},
+	})
+	st.Run(true)
+}
+
 func TestIncludeRubyToolVersionsIfRubyGRPCCLient(t *testing.T) {
 	st := stenciltest.New(t, "testdata/tool-versions-ruby/.tool-versions.tpl", libraryTmpls...)
 	st.Args(map[string]interface{}{


### PR DESCRIPTION
## What this PR does / why we need it

Avoids adding an extra empty line at the beginning of the `StartServers` function, which is a lint error.

Also fixes a weird mixed whitespace issue found when generating a snapshot of the same file. (This is normally fixed with `go fmt` so it's not an issue in practice.)

## Jira ID

[DT-4160]

[DT-4160]: https://outreach-io.atlassian.net/browse/DT-4160?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ