### PR TITLE
fix(deployments): remove unused import

### DIFF
--- a/templates/deployments/appname/resources.libsonnet.tpl
+++ b/templates/deployments/appname/resources.libsonnet.tpl
@@ -9,8 +9,6 @@
 local ok = import 'kubernetes/outreach.libsonnet';
 local app = (import 'kubernetes/app.libsonnet').info('{{ .Config.Name }}');
 
-local accounts = import './mixins/accounts.env.jsonnet';
-
 // Resource override for various enviornments go here.
 //
 // If a deployment matches on more than one of the overrides then


### PR DESCRIPTION
## What this PR does / why we need it

`deployment/$APP/mixins/accounts.env.jsonnet` doesn't seem to exist anymore and it's not referenced anywhere in this file.