### PR TITLE
fix: update the certficiate authority for rds

### DIFF
--- a/templates/.snapshots/TestRenderDeploymentDockerfile-deployments-appname-Dockerfile.tpl-deployments-testing-Dockerfile.snapshot
+++ b/templates/.snapshots/TestRenderDeploymentDockerfile-deployments-appname-Dockerfile.tpl-deployments-testing-Dockerfile.snapshot
@@ -34,9 +34,10 @@ ENV ZONEINFO=/zoneinfo.zip
 
 # Install certificates for RDS connectivity.
 RUN apk add --no-cache curl \
-    &&  curl "https://s3.amazonaws.com/rds-downloads/rds-combined-ca-bundle.pem" --output /usr/local/share/ca-certificates/rds-combined-ca-bundle.pem \
-    &&  update-ca-certificates \
-    &&  apk del --no-cache curl
+    && curl "https://truststore.pki.rds.amazonaws.com/global/global-bundle.pem" \
+      --output /usr/local/share/ca-certificates/global-bundle.pem \
+    && update-ca-certificates \
+    && apk del --no-cache curl
 
 ## <<Stencil::Block(afterBuild)>>
 

--- a/templates/deployments/appname/Dockerfile.tpl
+++ b/templates/deployments/appname/Dockerfile.tpl
@@ -37,9 +37,10 @@ ENV ZONEINFO=/zoneinfo.zip
 
 # Install certificates for RDS connectivity.
 RUN apk add --no-cache curl \
-    &&  curl "https://s3.amazonaws.com/rds-downloads/rds-combined-ca-bundle.pem" --output /usr/local/share/ca-certificates/rds-combined-ca-bundle.pem \
-    &&  update-ca-certificates \
-    &&  apk del --no-cache curl
+    && curl "https://truststore.pki.rds.amazonaws.com/global/global-bundle.pem" \
+      --output /usr/local/share/ca-certificates/global-bundle.pem \
+    && update-ca-certificates \
+    && apk del --no-cache curl
 
 ## <<Stencil::Block(afterBuild)>>
 {{ file.Block "afterBuild" }}


### PR DESCRIPTION
The rds-combined-ca-bundle.pem has expired certificate authority keys, updating with latest global bundle.

