### PR TITLE
fix: remove the mandatory internal module import to avoid failure

### DIFF
--- a/templates/cmd/main.go.tpl
+++ b/templates/cmd/main.go.tpl
@@ -24,7 +24,6 @@ import (
 	"github.com/getoutreach/stencil-golang/pkg/serviceactivities/gomaxprocs"
 	"github.com/pkg/errors"
 
-	"{{ stencil.ApplyTemplate "appImportPath" }}/internal/{{ .Config.Name }}"
 
 	{{- $additionalImports := stencil.GetModuleHook "main/additionalImports" }}
 	{{- if $additionalImports }}


### PR DESCRIPTION
<!--
  !!!! README !!!! Please fill this out.

  Please follow conventional commit naming conventions:

  https://www.conventionalcommits.org/en/v1.0.0/#summary
-->

Please read [CONTRIBUTING.md](CONTRIBUTING.md) for additional information on contributing to this repository!

<!-- A short description of what your PR does and what it solves. -->
## What this PR does / why we need it
This is to fix stencil for `eng` repo, when the appImportPath is not the expected package path. See the error details in the bug. The formatter will add the necessary import for internal package later.

<!-- <<Stencil::Block(jiraPrefix)>> -->

## Jira ID

[DT-4293]

<!-- <</Stencil::Block>> -->

<!-- Notes that may be helpful for anyone reviewing this PR -->
## Notes for your reviewers

<!-- <<Stencil::Block(custom)>> -->

<!-- <</Stencil::Block>> -->


[DT-4293]: https://outreach-io.atlassian.net/browse/DT-4293?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ