### PR TITLE
fix: upgrade controller-gen to 0.14.0 to fix panic

### DIFF
--- a/templates/api/kubernetes/version.go.tpl
+++ b/templates/api/kubernetes/version.go.tpl
@@ -10,7 +10,7 @@
 package {{ .version }}
 
 //nolint:lll //Why: Long shell script
-//go:generate /usr/bin/env bash -c "pushd ../../..{{if not (empty .package)}}/..{{end}} >/dev/null 2>&1 && ./scripts/shell-wrapper.sh gobin.sh sigs.k8s.io/controller-tools/cmd/controller-gen@v0.7.0 object paths=./api/k8s/{{ .package }}/{{ .version }} && popd >/dev/null 2>&1"
+//go:generate /usr/bin/env bash -c "pushd ../../..{{if not (empty .package)}}/..{{end}} >/dev/null 2>&1 && ./scripts/shell-wrapper.sh gobin.sh sigs.k8s.io/controller-tools/cmd/controller-gen@v0.14.0 object paths=./api/k8s/{{ .package }}/{{ .version }} && popd >/dev/null 2>&1"
 {{ end }}
 
 {{- range $g := stencil.Arg "kubernetes.groups" }}


### PR DESCRIPTION
controller-gen panics on some of our repos now, specifically found this in database-credential-operator.

```
go run sigs.k8s.io/controller-tools/cmd/controller-gen@v0.7.0 object paths=./api/k8s/database/v1
panic: runtime error: invalid memory address or nil pointer dereference [recovered]
        panic: runtime error: invalid memory address or nil pointer dereference
[signal SIGSEGV: segmentation violation code=0x2 addr=0x0 pc=0x103280e80]

```

https://github.com/kubernetes-sigs/controller-tools/issues/888
