### PR TITLE
feat: send appName as an identifier in LD context

### DIFF
--- a/templates/.snapshots/TestRenderDeploymentJsonnet-deployments-appname-app.jsonnet.tpl-deployments-testing-testing.jsonnet.snapshot
+++ b/templates/.snapshots/TestRenderDeploymentJsonnet-deployments-appname-app.jsonnet.tpl-deployments-testing-testing.jsonnet.snapshot
@@ -103,6 +103,7 @@ local all = {
 				Path: '/run/secrets/outreach.io/launchdarkly/sdk-key',
 			},
 			flagsToAdd: {
+				appName: app.name,
 				bento: app.bento,
 				channel: if isDev then 'dev' else app.channel,
 			} + if isDev then {

--- a/templates/.snapshots/TestRenderDeploymentJsonnetWithHPA-deployments-appname-app.jsonnet.tpl-deployments-testing-testing.jsonnet.snapshot
+++ b/templates/.snapshots/TestRenderDeploymentJsonnetWithHPA-deployments-appname-app.jsonnet.tpl-deployments-testing-testing.jsonnet.snapshot
@@ -103,6 +103,7 @@ local all = {
 				Path: '/run/secrets/outreach.io/launchdarkly/sdk-key',
 			},
 			flagsToAdd: {
+				appName: app.name,
 				bento: app.bento,
 				channel: if isDev then 'dev' else app.channel,
 			} + if isDev then {

--- a/templates/.snapshots/TestRenderDeploymentJsonnet_Canary-deployments-appname-app.jsonnet.tpl-deployments-testing-testing.jsonnet.snapshot
+++ b/templates/.snapshots/TestRenderDeploymentJsonnet_Canary-deployments-appname-app.jsonnet.tpl-deployments-testing-testing.jsonnet.snapshot
@@ -138,6 +138,7 @@ local all = {
 				Path: '/run/secrets/outreach.io/launchdarkly/sdk-key',
 			},
 			flagsToAdd: {
+				appName: app.name,
 				bento: app.bento,
 				channel: if isDev then 'dev' else app.channel,
 			} + if isDev then {

--- a/templates/.snapshots/TestRenderDeploymentJsonnet_Canary_emptyServiceActivities-deployments-appname-app.jsonnet.tpl-deployments-testing-testing.jsonnet.snapshot
+++ b/templates/.snapshots/TestRenderDeploymentJsonnet_Canary_emptyServiceActivities-deployments-appname-app.jsonnet.tpl-deployments-testing-testing.jsonnet.snapshot
@@ -110,6 +110,7 @@ local all = {
 				Path: '/run/secrets/outreach.io/launchdarkly/sdk-key',
 			},
 			flagsToAdd: {
+				appName: app.name,
 				bento: app.bento,
 				channel: if isDev then 'dev' else app.channel,
 			} + if isDev then {

--- a/templates/.snapshots/TestUseKIAMFalse-deployments-appname-app.jsonnet.tpl-deployments-testing-testing.jsonnet.snapshot
+++ b/templates/.snapshots/TestUseKIAMFalse-deployments-appname-app.jsonnet.tpl-deployments-testing-testing.jsonnet.snapshot
@@ -105,6 +105,7 @@ local all = {
 				Path: '/run/secrets/outreach.io/launchdarkly/sdk-key',
 			},
 			flagsToAdd: {
+				appName: app.name,
 				bento: app.bento,
 				channel: if isDev then 'dev' else app.channel,
 			} + if isDev then {

--- a/templates/deployments/appname/app.jsonnet.tpl
+++ b/templates/deployments/appname/app.jsonnet.tpl
@@ -169,7 +169,7 @@ local all = {
 				Path: '/run/secrets/outreach.io/launchdarkly/sdk-key',
 			},
 			flagsToAdd: {
-        appName: app.name,
+				appName: app.name,
 				bento: app.bento,
 				channel: if isDev then 'dev' else app.channel,
 			} + if isDev then {

--- a/templates/deployments/appname/app.jsonnet.tpl
+++ b/templates/deployments/appname/app.jsonnet.tpl
@@ -169,6 +169,7 @@ local all = {
 				Path: '/run/secrets/outreach.io/launchdarkly/sdk-key',
 			},
 			flagsToAdd: {
+        appName: app.name,
 				bento: app.bento,
 				channel: if isDev then 'dev' else app.channel,
 			} + if isDev then {


### PR DESCRIPTION
<!--
  !!!! README !!!! Please fill this out.

  Please follow conventional commit naming conventions:

  https://www.conventionalcommits.org/en/v1.0.0/#summary
-->
<!-- A short description of what your PR does and what it solves. -->
## What this PR does / why we need it
Update LaunchDarkly context by introducing `appName` property in the user context. This property is already used by client-side SDK (OrCA) to identify various apps built in OrCA. In order to have a better overview of usage of flags across our codebase, we're introducing the `appName` property across all LD clients.

This is a backwards compatible change because it doesn't change how existing flags are evaluated. It's not expected to use this new property in feature flag targeting; instead, this will come in handy as a debugging/organization tool.

Recently, there were at least two occasions where this would have been useful:
1. An SDK sending invalid value of user id 
2. An SDK sending incorrect insights data

In both cases, having the `appName` would speed up the fault detection.

<!-- <<Stencil::Block(jiraPrefix)>> -->

## Jira ID

[XX-XX]

<!-- <</Stencil::Block>> -->

<!-- Notes that may be helpful for anyone reviewing this PR -->
## Notes for your reviewers

<!-- <<Stencil::Block(custom)>> -->

<!-- <</Stencil::Block>> -->
