### PR TITLE
fix: pin grpc-js

### DIFF
--- a/templates/_helpers.tpl
+++ b/templates/_helpers.tpl
@@ -154,7 +154,7 @@ go:
 nodejs:
   dependencies:
   - name: "@grpc/grpc-js"
-    version: ^1.7.3
+    version: "1.7.3"
   - name: "@grpc/proto-loader"
     version: ^0.5.5
   - name: "@getoutreach/grpc-client"


### PR DESCRIPTION
* it has to be pinned because it will end up indirectly resolving latest
  which will not build
