### PR TITLE
fix(grpc): don't emit gRPC clients for libraries

### DIFF
--- a/scripts/.tool-versions
+++ b/scripts/.tool-versions
@@ -1,2 +1,0 @@
-# needed for CI
-golang 1.17.9

--- a/templates/api/clients/node/src/client-helpers.spec.ts.tpl
+++ b/templates/api/clients/node/src/client-helpers.spec.ts.tpl
@@ -1,4 +1,7 @@
 {{- $_ := stencil.ApplyTemplate "skipGrpcClient" "node" -}}
+{{- if not (stencil.Arg "service") }}
+{{- $_ := file.Skip "No client generated for libraries" }}
+{{- end }}
 describe('{{ .Config.Name }} client', () => {
   it('asserts true # please fill this test in with your own', () => {
     expect(true).toBeTruthy();

--- a/templates/api/clients/node/src/client-helpers.ts.tpl
+++ b/templates/api/clients/node/src/client-helpers.ts.tpl
@@ -1,4 +1,7 @@
 {{- $_ := stencil.ApplyTemplate "skipGrpcClient" "node" -}}
+{{- if not (stencil.Arg "service") }}
+{{- $_ := file.Skip "No client generated for libraries" }}
+{{- end }}
 import * as grpc from '@grpc/grpc-js';
 import { {{ stencil.ApplyTemplate "serviceNameLanguageSafe" }}Client } from './grpc/{{ .Config.Name }}_grpc_pb';
 import { createErrorLoggerInterceptor } from '@getoutreach/grpc-client';

--- a/templates/api/clients/node/src/index.ts.tpl
+++ b/templates/api/clients/node/src/index.ts.tpl
@@ -1,6 +1,8 @@
 {{- $_ := stencil.ApplyTemplate "skipGrpcClient" "node" -}}
+{{- if stencil.Arg "service" }}
 export * as {{ stencil.ApplyTemplate "serviceNameLanguageSafe" }}Types from './grpc/{{ .Config.Name }}_pb';
 export * from './client-helpers';
 
 import { {{ stencil.ApplyTemplate "serviceNameLanguageSafe" }}Client } from './grpc/{{ .Config.Name }}_grpc_pb';
 export default {{ stencil.ApplyTemplate "serviceNameLanguageSafe" }}Client;
+{{- end }}

--- a/templates/api/clients/ruby/lib/client.rb.tpl
+++ b/templates/api/clients/ruby/lib/client.rb.tpl
@@ -1,11 +1,10 @@
-# {{ stencil.ApplyTemplate "copyright" }} 
-{{- if not (has "grpc" (stencil.Arg "serviceActivities")) }}
-{{ file.Skip "Not a gRPC service" }}
-{{- end }}
+# {{ stencil.ApplyTemplate "copyright" }}
 {{- $_ := file.SetPath (printf "api/clients/ruby/lib/%s_client.rb" .Config.Name) }}
 {{- $_ := stencil.ApplyTemplate "skipGrpcClient" "ruby" }}
 
 require "{{ .Config.Name }}_client/client"
 require "{{ .Config.Name }}_client/version"
+{{- if stencil.Arg "service" }}
 require "{{ .Config.Name }}_client/{{ .Config.Name }}_pb"
 require "{{ .Config.Name }}_client/{{ .Config.Name }}_services_pb"
+{{- end }}

--- a/templates/api/clients/ruby/lib/client/client.rb.tpl
+++ b/templates/api/clients/ruby/lib/client/client.rb.tpl
@@ -1,14 +1,17 @@
-# {{ stencil.ApplyTemplate "copyright" }} 
+# {{ stencil.ApplyTemplate "copyright" }}
 {{- $_ := stencil.ApplyTemplate "skipGrpcClient" "ruby" -}}
 {{- $_ := file.SetPath (printf "api/clients/ruby/lib/%s_client/%s" .Config.Name (base file.Path)) }}
 
+{{- if stencil.Arg "service" }}
 require "{{ .Config.Name }}_client/{{ .Config.Name }}_pb"
 require "{{ .Config.Name }}_client/{{ .Config.Name }}_services_pb"
+{{- end }}
 
 ## <<Stencil::Block(rubyModuleGlobalSpaceInclusions)>>
 {{ file.Block "rubyModuleGlobalSpaceInclusions" }}
 ## <</Stencil::Block>>
 
+{{- if stencil.Arg "service" }}
 module {{ title .Config.Name }}Client
   class Client < {{ title .Config.Name }}::Stub
     class Interceptor < GRPC::ClientInterceptor
@@ -69,3 +72,4 @@ module {{ title .Config.Name }}Client
 {{ file.Block "rubyModuleExtensions" }}
   ## <</Stencil::Block>>
 end
+{{- end }}


### PR DESCRIPTION
## What this PR does / why we need it

When generating client packages for libraries, they won't have the actual client generated, but just the types around it. So don't emit the client classes or helpers.

## Jira ID

[DT-4300]

[DT-4300]: https://outreach-io.atlassian.net/browse/DT-4300?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ