### PR TITLE
fix(ruby): update gemspec description/ruby version

### DIFF
--- a/templates/api/clients/ruby/client.gemspec.tpl
+++ b/templates/api/clients/ruby/client.gemspec.tpl
@@ -15,7 +15,7 @@ Gem::Specification.new do |spec|
   spec.metadata["source_code_uri"] = spec.homepage
   spec.metadata["github_repo"] = "ssh://github.com/getoutreach/{{ .Config.Name }}"
 
-  spec.required_ruby_version = Gem::Requirement.new(">= 2.7.5")
+  spec.required_ruby_version = Gem::Requirement.new(">= {{ stencil.Arg "versions.grpcClients.ruby" }}")
   spec.files         = Dir.chdir(File.expand_path('..', __FILE__)) do
     `git ls-files -z`.split("\x0").reject { |f| f.match(%r{^(test|spec|features)/}) }
   end

--- a/templates/api/clients/ruby/client.gemspec.tpl
+++ b/templates/api/clients/ruby/client.gemspec.tpl
@@ -4,7 +4,11 @@ require_relative 'lib/{{ .Config.Name }}_client/version'
 Gem::Specification.new do |spec|
   spec.name          = "{{ .Config.Name }}_client"
   spec.version       = {{ title .Config.Name }}Client::VERSION
-  spec.summary       = "ruby client for {{ .Config.Name }} service"
+  {{- if stencil.Arg "service" }}
+  spec.summary       = "gRPC client for {{ .Config.Name }} service"
+  {{- else }}
+  spec.summary       = "gRPC types for {{ .Config.Name }}"
+  {{- end }}
   spec.authors       = ["{{ stencil.Arg "reportingTeam" }}"]
   spec.homepage      = "https://github.com/getoutreach/{{ .Config.Name }}"
   spec.metadata["homepage_uri"] = spec.homepage


### PR DESCRIPTION
## What this PR does / why we need it

* [set gem summary based on whether it's a service](https://github.com/getoutreach/stencil-golang/commit/a0cbd9feb2f21b033b0d6960a0e1f59c071cfdec)
* [sync required ruby version with ruby client version](https://github.com/getoutreach/stencil-golang/commit/25962549b8c1d3dcb778d403e68ee5b01647e72d)

## Jira ID

[DT-4300]


[DT-4300]: https://outreach-io.atlassian.net/browse/DT-4300?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ