### PR TITLE
fix(docker): avoid installing curl for the RDS certificates

### DIFF
--- a/templates/.snapshots/TestRenderDeploymentDockerfile-deployments-appname-Dockerfile.tpl-deployments-testing-Dockerfile.snapshot
+++ b/templates/.snapshots/TestRenderDeploymentDockerfile-deployments-appname-Dockerfile.tpl-deployments-testing-Dockerfile.snapshot
@@ -33,11 +33,9 @@ COPY --from=builder /usr/local/go/lib/time/zoneinfo.zip /zoneinfo.zip
 ENV ZONEINFO=/zoneinfo.zip
 
 # Install certificates for RDS connectivity.
-RUN apk add --no-cache curl \
-    && curl "https://truststore.pki.rds.amazonaws.com/global/global-bundle.pem" \
-      --output /usr/local/share/ca-certificates/global-bundle.pem \
-    && update-ca-certificates \
-    && apk del --no-cache curl
+RUN wget --output-document /usr/local/share/ca-certificates/global-bundle.pem \
+  "https://truststore.pki.rds.amazonaws.com/global/global-bundle.pem" \
+  && update-ca-certificates
 
 ## <<Stencil::Block(afterBuild)>>
 

--- a/templates/deployments/appname/Dockerfile.tpl
+++ b/templates/deployments/appname/Dockerfile.tpl
@@ -36,11 +36,9 @@ COPY --from=builder /usr/local/go/lib/time/zoneinfo.zip /zoneinfo.zip
 ENV ZONEINFO=/zoneinfo.zip
 
 # Install certificates for RDS connectivity.
-RUN apk add --no-cache curl \
-    && curl "https://truststore.pki.rds.amazonaws.com/global/global-bundle.pem" \
-      --output /usr/local/share/ca-certificates/global-bundle.pem \
-    && update-ca-certificates \
-    && apk del --no-cache curl
+RUN wget --output-document /usr/local/share/ca-certificates/global-bundle.pem \
+  "https://truststore.pki.rds.amazonaws.com/global/global-bundle.pem" \
+  && update-ca-certificates
 
 ## <<Stencil::Block(afterBuild)>>
 {{ file.Block "afterBuild" }}


### PR DESCRIPTION
## What this PR does / why we need it

In Alpine Linux, `curl` isn't installed by default, but `busybox` is. `busybox` contains a `wget` applet which has the equivalent functionality for what we need here. When the image layer isn't cached, it seems to go from 1.1s to 0.2s.