### PR TITLE
ci: add ci configuration allow manual and automatic rc release

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -9,6 +9,9 @@ parameters:
   rebuild_cache:
     type: boolean
     default: false
+  release_rc:
+    type: boolean
+    default: false
 
 # Extra contexts to expose to all jobs below
 contexts: &contexts
@@ -75,9 +78,30 @@ workflows:
     jobs:
       - shared/save_cache: *test
 
+  auto-release-rc:
+    triggers:
+      - schedule:
+          # automatically release rc on every Tuesday 12pm(PST).
+          cron: "0 7 * * 2"
+          filters:
+            branches:
+              only:
+                - main
+    jobs:
+      - shared/trigger_rc_release:
+          context: *contexts
+
+  maunail-release-rc:
+    when: << pipeline.parameters.release_rc>>
+    jobs:
+      - shared/trigger_rc_release:
+          context: *contexts
+
   release:
     when:
-      not: << pipeline.parameters.rebuild_cache >>
+      and:
+        - not: << pipeline.parameters.rebuild_cache >>
+        - not: << pipeline.parameters.release_rc >>
     jobs:
       ## <<Stencil::Block(circleWorkflowJobs)>>
 

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -91,7 +91,7 @@ workflows:
       - shared/trigger_rc_release:
           context: *contexts
 
-  maunail-release-rc:
+  manual-release-rc:
     when: << pipeline.parameters.release_rc>>
     jobs:
       - shared/trigger_rc_release:


### PR DESCRIPTION
<!--
  !!!! README !!!! Please fill this out.

  Please follow conventional commit naming conventions:

  https://www.conventionalcommits.org/en/v1.0.0/#summary
-->

Please read [CONTRIBUTING.md](CONTRIBUTING.md) for additional information on contributing to this repository!

<!-- A short description of what your PR does and what it solves. -->
## What this PR does / why we need it
The scheduled rc release will be triggered automatically on every Tuesday noon, to avoid rc get into stable without testing.
To manually trigger the pipeline on CircleCI UI:
![image](https://github.com/getoutreach/stencil-golang/assets/134322381/dd339824-4838-495d-a9c3-f97a6b4e5f07)

After the workflow is verified, the ci config should be added to the `stencil-circleci` template.

<!-- <<Stencil::Block(jiraPrefix)>> -->

## Jira ID

[DT-4239]

<!-- <</Stencil::Block>> -->

<!-- Notes that may be helpful for anyone reviewing this PR -->
## Notes for your reviewers

<!-- <<Stencil::Block(custom)>> -->

<!-- <</Stencil::Block>> -->


[DT-4239]: https://outreach-io.atlassian.net/browse/DT-4239?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ