### PR TITLE
chore: change ownership of Ruby gRPC client to FND: PC

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -2,5 +2,8 @@
 * @getoutreach/fnd-dt
 
 ## <<Stencil::Block(customCodeowners)>>
-
+templates/.snapshots/Test*Ruby*.snapshot @getoutreach/fnd-pc
+templates/api/clients/ruby @getoutreach/fnd-pc
+templates/ruby_test.go @getoutreach/fnd-pc
+templates/testdata/tool-versions-ruby @getoutreach/fnd-pc
 ## <</Stencil::Block>>

--- a/templates/main_test.go
+++ b/templates/main_test.go
@@ -233,31 +233,6 @@ func TestGRPCServerRPC(t *testing.T) {
 	st.Run(true)
 }
 
-func TestIncludeRubyToolVersionsIfRubyGRPCClient(t *testing.T) {
-	st := stenciltest.New(t, "testdata/tool-versions-ruby/.tool-versions.tpl", libraryTmpls...)
-	st.Args(map[string]interface{}{
-		"grpcClients": []interface{}{"ruby"},
-	})
-	st.Run(stenciltest.RegenerateSnapshots())
-}
-
-func TestIncludeRubyToolVersionsIfRubyGRPCClientLibrary(t *testing.T) {
-	// Need to use testdata because stenciltest cannot test file.Skip
-	st := stenciltest.New(t, "testdata/tool-versions-ruby/.tool-versions.tpl", libraryTmpls...)
-	st.Args(map[string]interface{}{
-		"grpcClients":       []interface{}{"ruby"},
-		"service":           false,
-		"serviceActivities": []interface{}{},
-	})
-	st.Run(stenciltest.RegenerateSnapshots())
-}
-
-func TestDontIncludeRubyToolVersionsIfNotRubyGRPCClient(t *testing.T) {
-	st := stenciltest.New(t, "testdata/tool-versions-ruby/.tool-versions.tpl", libraryTmpls...)
-	st.Args(map[string]interface{}{})
-	st.Run(stenciltest.RegenerateSnapshots())
-}
-
 func TestGoreleaserYml(t *testing.T) {
 	st := stenciltest.New(t, ".goreleaser.yml.tpl", libraryTmpls...)
 	st.Args(map[string]interface{}{

--- a/templates/ruby_test.go
+++ b/templates/ruby_test.go
@@ -1,0 +1,36 @@
+// Copyright 2024 Outreach Corporation. All Rights Reserved.
+
+// Description: Template tests specific to the Ruby gRPC client.
+
+package main_test
+
+import (
+	"testing"
+
+	"github.com/getoutreach/stencil/pkg/stenciltest"
+)
+
+func TestIncludeRubyToolVersionsIfRubyGRPCClient(t *testing.T) {
+	st := stenciltest.New(t, "testdata/tool-versions-ruby/.tool-versions.tpl", libraryTmpls...)
+	st.Args(map[string]interface{}{
+		"grpcClients": []interface{}{"ruby"},
+	})
+	st.Run(stenciltest.RegenerateSnapshots())
+}
+
+func TestIncludeRubyToolVersionsIfRubyGRPCClientLibrary(t *testing.T) {
+	// Need to use testdata because stenciltest cannot test file.Skip
+	st := stenciltest.New(t, "testdata/tool-versions-ruby/.tool-versions.tpl", libraryTmpls...)
+	st.Args(map[string]interface{}{
+		"grpcClients":       []interface{}{"ruby"},
+		"service":           false,
+		"serviceActivities": []interface{}{},
+	})
+	st.Run(stenciltest.RegenerateSnapshots())
+}
+
+func TestDontIncludeRubyToolVersionsIfNotRubyGRPCClient(t *testing.T) {
+	st := stenciltest.New(t, "testdata/tool-versions-ruby/.tool-versions.tpl", libraryTmpls...)
+	st.Args(map[string]interface{}{})
+	st.Run(stenciltest.RegenerateSnapshots())
+}


### PR DESCRIPTION
## What this PR does / why we need it

DT doesn't have enough context to adequately maintain support for the Ruby gRPC client templates, so we're handing off ownership to FND: PC as they currently "own" Flagship (the only consumer of the Ruby clients).

CC: @george-e-shaw-iv (per what we discussed in Slack)