### PR TITLE
fix: upgrade build tools Node.js version to 20 LTS

### DIFF
--- a/.tool-versions
+++ b/.tool-versions
@@ -5,7 +5,7 @@
 ## <<Stencil::Block(toolverOverride)>>
 ## <</Stencil::Block>>
 golang 1.22.0
-nodejs 18.17.1
+nodejs 20.12.2
 protoc 21.5
 # Note: Versions in this block do not override the default versions above
 # but sometimes you have to declare additional versions of the same tool

--- a/manifest.yaml
+++ b/manifest.yaml
@@ -177,7 +177,7 @@ arguments:
         - number
   versions.nodejs:
     description: Nodejs version to use for build tooling (e.g., semantic-release)
-    default: "18.17.1"
+    default: "20.12.2"
     schema:
       type:
         - string

--- a/templates/.snapshots/TestIncludeRubyToolVersionsIfRubyGRPCClient-testdata-tool-versions-ruby-.tool-versions.tpl-testdata-tool-versions-ruby-.tool-versions.snapshot
+++ b/templates/.snapshots/TestIncludeRubyToolVersionsIfRubyGRPCClient-testdata-tool-versions-ruby-.tool-versions.tpl-testdata-tool-versions-ruby-.tool-versions.snapshot
@@ -4,7 +4,7 @@
   version: '1.22.0'
 # Not used for gRPC clients
 - name: nodejs
-  version: 18.17.1
+  version: 20.12.2
 # Used in CI
 - name: protoc
   version: 21.5

--- a/templates/.snapshots/TestIncludeRubyToolVersionsIfRubyGRPCClientLibrary-testdata-tool-versions-ruby-.tool-versions.tpl-testdata-tool-versions-ruby-.tool-versions.snapshot
+++ b/templates/.snapshots/TestIncludeRubyToolVersionsIfRubyGRPCClientLibrary-testdata-tool-versions-ruby-.tool-versions.tpl-testdata-tool-versions-ruby-.tool-versions.snapshot
@@ -4,7 +4,7 @@
   version: '1.22.0'
 # Not used for gRPC clients
 - name: nodejs
-  version: 18.17.1
+  version: 20.12.2
 # Used in CI
 - name: protoc
   version: 21.5


### PR DESCRIPTION
## What this PR does / why we need it

This is the companion PR to https://github.com/getoutreach/stencil-base/pull/159

## Jira ID

[DT-4322]

[DT-4322]: https://outreach-io.atlassian.net/browse/DT-4322?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ