### PR TITLE
fix(nodejs): remove unused wait-on devDependency

### DIFF
--- a/templates/.snapshots/TestRenderDependabot-.github-dependabot.yml.tpl-.github-dependabot.yml.snapshot
+++ b/templates/.snapshots/TestRenderDependabot-.github-dependabot.yml.tpl-.github-dependabot.yml.snapshot
@@ -56,7 +56,6 @@ updates:
       - dependency-name: "ts-node"
       - dependency-name: "tsconfig-paths"
       - dependency-name: "typescript"
-      - dependency-name: "wait-on"
 
   ## <<Stencil::Block(dependabotPackageManagers)>>
 

--- a/templates/_helpers.tpl
+++ b/templates/_helpers.tpl
@@ -214,8 +214,6 @@ nodejs:
     version: ^3.9.0
   - name: typescript
     version: ^4.0.5
-  - name: wait-on
-    version: ^6.0.1
 {{- range stencil.GetModuleHook "js_modules_dev" }}
   - name: {{ .name }}
     version: {{ .version }}


### PR DESCRIPTION
## What this PR does / why we need it

As far as I can tell, `wait-on` has never been used in the entire history of the Node.js gRPC client :rage4:

## Jira ID

[DT-4345]

[DT-4345]: https://outreach-io.atlassian.net/browse/DT-4345?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ