### PR TITLE
chore: restencil to use unstable devbase instead of a nonexistent branch

### DIFF
--- a/.releaserc.yaml
+++ b/.releaserc.yaml
@@ -1,7 +1,7 @@
 preset: conventionalcommits
 branches:
   - name: main
-    prerelease: rc
+    prerelease: "rc"
   - name: release
 plugins:
   - - "@semantic-release/commit-analyzer"

--- a/service.yaml
+++ b/service.yaml
@@ -23,6 +23,5 @@ modules:
   - name: github.com/getoutreach/stencil-circleci
   - name: github.com/getoutreach/stencil-base
   - name: github.com/getoutreach/devbase
-    url: https://github.com/getoutreach/devbase
-    version: yjyan/change-prerelease
+    version: main
   - name: github.com/getoutreach/stencil-golang

--- a/stencil.lock
+++ b/stencil.lock
@@ -2,13 +2,13 @@ version: v1.38.0
 modules:
     - name: github.com/getoutreach/devbase
       url: https://github.com/getoutreach/devbase
-      version: yjyan/change-prerelease
+      version: main
     - name: github.com/getoutreach/stencil-base
       url: https://github.com/getoutreach/stencil-base
-      version: v0.15.1
+      version: v0.15.2
     - name: github.com/getoutreach/stencil-circleci
       url: https://github.com/getoutreach/stencil-circleci
-      version: v1.12.0
+      version: v1.12.1
     - name: github.com/getoutreach/stencil-golang
       url: file://./
       version: local


### PR DESCRIPTION
## What this PR does / why we need it

This fixes CI now that https://github.com/getoutreach/devbase/pull/743 is merged.