### PR TITLE
fix: allow hyphenated services

### DIFF
--- a/templates/.snapshots/TestGRPCServerRPC-internal-appName-rpc-rpc.go.tpl-internal-testing-rpc.go.snapshot
+++ b/templates/.snapshots/TestGRPCServerRPC-internal-appName-rpc-rpc.go.tpl-internal-testing-rpc.go.snapshot
@@ -6,7 +6,7 @@
 // exists in the server.go file in this same directory.
 // Managed: true
 
-package testing //nolint:revive // Why: We allow [-_].
+package testing //nolint:revive,doculint // Why: We allow [-_].
 
 import (
 	"context"

--- a/templates/api/rpc/client.go.tpl
+++ b/templates/api/rpc/client.go.tpl
@@ -9,7 +9,7 @@
 // Description: This file contains the gRPC client implementation for the
 // {{ .Config.Name }} service.
 
-package {{ stencil.ApplyTemplate "goPackageSafeName" }} //nolint:revive // Why: We allow [-_].
+package {{ stencil.ApplyTemplate "goPackageSafeName" }} //nolint:revive,doculint // Why: We allow [-_].
 
 import (
 	"context"

--- a/templates/api/rpc/doc.go.tpl
+++ b/templates/api/rpc/doc.go.tpl
@@ -9,4 +9,4 @@
 
 // Package {{ stencil.ApplyTemplate "goPackageSafeName" }} implements the client interface to the
 // {{ .Config.Name }} gRPC service.
-package {{ stencil.ApplyTemplate "goPackageSafeName" }} //nolint:revive // Why: We allow [-_].
+package {{ stencil.ApplyTemplate "goPackageSafeName" }} //nolint:revive,doculint // Why: We allow [-_].

--- a/templates/internal/appName/config.go.tpl
+++ b/templates/internal/appName/config.go.tpl
@@ -6,7 +6,7 @@
 // to various parts of the service.
 // Managed: true
 
-package {{ stencil.ApplyTemplate "goPackageSafeName" }} //nolint:revive // Why: We allow [-_].
+package {{ stencil.ApplyTemplate "goPackageSafeName" }} //nolint:revive,doculint // Why: We allow [-_].
 
 import (
 	"context"

--- a/templates/internal/appName/http/handler.go.tpl
+++ b/templates/internal/appName/http/handler.go.tpl
@@ -11,7 +11,7 @@
 {{- .}}
 {{- end }}
 
-package {{ stencil.ApplyTemplate "goPackageSafeName" }} //nolint:revive // Why: We allow [-_].
+package {{ stencil.ApplyTemplate "goPackageSafeName" }} //nolint:revive,doculint // Why: We allow [-_].
 import (
 	"net/http"
 {{- $extraStandardImports := (stencil.GetModuleHook "http/extraStandardImports") }}

--- a/templates/internal/appName/k8s/activity.go.tpl
+++ b/templates/internal/appName/k8s/activity.go.tpl
@@ -7,7 +7,7 @@
 
 // Description: This file implements a kubernetes controller or webhook for {{ .Config.Name }}.
 
-package {{ stencil.ApplyTemplate "goPackageSafeName" }} //nolint:revive // Why: We allow [-_].
+package {{ stencil.ApplyTemplate "goPackageSafeName" }} //nolint:revive,doculint // Why: We allow [-_].
 
 import (
 	"context"

--- a/templates/internal/appName/rpc/rpc.go.tpl
+++ b/templates/internal/appName/rpc/rpc.go.tpl
@@ -14,7 +14,7 @@
 {{- .}}
 {{- end }}
 
-package {{ $pkgName }} //nolint:revive // Why: We allow [-_].
+package {{ $pkgName }} //nolint:revive,doculint // Why: We allow [-_].
 
 import (
 	"context"


### PR DESCRIPTION
<!--
  !!!! README !!!! Please fill this out.

  Please follow conventional commit naming conventions:

  https://www.conventionalcommits.org/en/v1.0.0/#summary
-->

Please read [CONTRIBUTING.md](CONTRIBUTING.md) for additional information on contributing to this repository!

<!-- A short description of what your PR does and what it solves. -->
## What this PR does / why we need it
- This addition ignores a linter error thrown when re-stenciling services with a `_` in their service name. 
- According to the templated comment, we should allow these names:
  - `Why: We allow [-_].` 
- When re-stenciling a `data-sharing-service` (gocode service uses a `_` in the name), the following error is thrown:
  - `api/data-sharing-service/doc.go:8:1: package "data_sharing_service" should not contain - or _ in name (doculint)`  



<!-- <<Stencil::Block(jiraPrefix)>> -->

## Jira ID

[XX-XX]

<!-- <</Stencil::Block>> -->

<!-- Notes that may be helpful for anyone reviewing this PR -->
## Notes for your reviewers

<!-- <<Stencil::Block(custom)>> -->

<!-- <</Stencil::Block>> -->
