### PR TITLE
fix: remove trailing whitespace from Makefile

### DIFF
--- a/templates/Makefile.tpl
+++ b/templates/Makefile.tpl
@@ -1,6 +1,6 @@
 APP := {{ .Config.Name }}
 OSS := {{ stencil.Arg "oss" }}
-_ := $(shell ./scripts/devbase.sh) 
+_ := $(shell ./scripts/devbase.sh)
 
 include .bootstrap/root/Makefile
 


### PR DESCRIPTION
## What this PR does / why we need it

This should fix the conflict between re-running `stencil` and editing `Makefile` in an editor that supports EditorConfig.