### PR TITLE
fix(nodejs): remove unused `@grpc/proto-loader` & sync `@grpc/grpc-js` version

### DIFF
--- a/templates/.snapshots/TestRenderDependabot-.github-dependabot.yml.tpl-.github-dependabot.yml.snapshot
+++ b/templates/.snapshots/TestRenderDependabot-.github-dependabot.yml.tpl-.github-dependabot.yml.snapshot
@@ -29,7 +29,6 @@ updates:
     # stencil-golang managed dependencies
     ignore:
       - dependency-name: "@grpc/grpc-js"
-      - dependency-name: "@grpc/proto-loader"
       - dependency-name: "@getoutreach/grpc-client"
       - dependency-name: "@getoutreach/find"
       - dependency-name: "@types/google-protobuf"

--- a/templates/_helpers.tpl
+++ b/templates/_helpers.tpl
@@ -155,8 +155,6 @@ nodejs:
   dependencies:
   - name: "@grpc/grpc-js"
     version: "1.7.3"
-  - name: "@grpc/proto-loader"
-    version: ^0.5.5
   - name: "@getoutreach/grpc-client"
     version: ^2.3.0
   - name: "@getoutreach/find"

--- a/templates/_helpers.tpl
+++ b/templates/_helpers.tpl
@@ -154,7 +154,8 @@ go:
 nodejs:
   dependencies:
   - name: "@grpc/grpc-js"
-    version: "1.7.3"
+    # This version should be synced with the same dependency in @getoutreach/grpc-client
+    version: "1.8.22"
   - name: "@getoutreach/grpc-client"
     version: ^2.3.0
   - name: "@getoutreach/find"


### PR DESCRIPTION
## What this PR does / why we need it

As far as I can tell, `@grpc/proto-loader` is not used in the Node.js gRPC client by default.

Also sync the version of `@grpc/grpc-js` version with the same version used in `@getoutreach/grpc-client` to get ahead of security vulnerability tickets.

## Jira ID

[DT-4422]

[DT-4422]: https://outreach-io.atlassian.net/browse/DT-4422?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ