### PR TITLE
fix(gomod): add toolchain directive

### DIFF
--- a/templates/.snapshots/TestBasicGoMod-go.mod.tpl-go.mod.snapshot
+++ b/templates/.snapshots/TestBasicGoMod-go.mod.tpl-go.mod.snapshot
@@ -2,6 +2,8 @@
 
 go 1.21
 
+toolchain go1.22.0
+
 require (
 	github.com/getoutreach/gobox v1.90.2
 	github.com/getoutreach/stencil-golang/pkg v0.0.0-20230811193316-312178c3fbc3

--- a/templates/.snapshots/TestGoModStanzaVersion-go.mod.tpl-go.mod.snapshot
+++ b/templates/.snapshots/TestGoModStanzaVersion-go.mod.tpl-go.mod.snapshot
@@ -2,6 +2,8 @@
 
 go 1.19
 
+toolchain go1.22.0
+
 require (
 	github.com/getoutreach/gobox v1.90.2
 	github.com/getoutreach/stencil-golang/pkg v0.0.0-20230811193316-312178c3fbc3

--- a/templates/go.mod.tpl
+++ b/templates/go.mod.tpl
@@ -11,6 +11,8 @@ go 1.17
 go {{ stencil.Arg "go.stanza" }}
 {{- end }}
 
+toolchain go{{ stencil.ApplyTemplate "goVersion" | trim }}
+
 require (
 	{{- range $d := (stencil.ApplyTemplate "dependencies" | fromYaml).go }}
 	{{ $d.name }} {{ $d.version }}


### PR DESCRIPTION

## What this PR does / why we need it

This should ensure that the Go version specified by the manifest is the same version as the toolchain used.