### PR TITLE
fix(nodejs): upgrade `@getoutreach/grpc-client` to ^2.4.0

### DIFF
--- a/templates/_helpers.tpl
+++ b/templates/_helpers.tpl
@@ -157,7 +157,7 @@ nodejs:
     # This version should be synced with the same dependency in @getoutreach/grpc-client
     version: "1.8.22"
   - name: "@getoutreach/grpc-client"
-    version: ^2.3.0
+    version: ^2.4.0
   - name: "@getoutreach/find"
     version: ^1.1.0
   - name: "@types/google-protobuf"


### PR DESCRIPTION
## What this PR does / why we need it

Sync the version of `@grpc/grpc-js` in the Node.js gRPC client with the version depended on by `@getoutreach/grpc-client`.

## Jira ID

[DT-4427]

[DT-4427]: https://outreach-io.atlassian.net/browse/DT-4427?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ