### PR TITLE
fix(nodejs): update TypeScript target/lib to ES2022

### DIFF
--- a/templates/api/clients/node/tsconfig.json.tpl
+++ b/templates/api/clients/node/tsconfig.json.tpl
@@ -4,7 +4,7 @@
     "module": "commonjs",
     "declaration": true,
     "esModuleInterop": true,
-    "target": "es2018",
+    "target": "ES2022",
     "noImplicitAny": true,
     "moduleResolution": "node",
     "sourceMap": true,
@@ -24,7 +24,7 @@
     only those found in the api/clients/nodes/node_modules/@types/ folder and nowhere else.
     */ -}}
     "typeRoots": ["node_modules/@types"],
-    "lib": ["es2018", "es2018.promise", "esnext.asynciterable", "dom"]
+    "lib": ["es2022"]
   },
   "include": ["src/**/*.ts", "src/**/*.js"],
   "exclude": ["node_modules", "codegen-templates"]


### PR DESCRIPTION
## What this PR does / why we need it

This should simplify the generated JS that's output. ES2022 is compatible with Node.js 20, see https://github.com/microsoft/TypeScript/wiki/Node-Target-Mapping for details. (Not using ES2023 because I don't want to upgrade TypeScript at the same time...)

This should also avoid some weird compatibility issues with `@types/node` and also removes an unnecessary `dom` include since there's no frontend code used here.