### PR TITLE
fix(nodejs): better messaging when prettier fails

### DIFF
--- a/templates/api/clients/node/package.hjson.tpl
+++ b/templates/api/clients/node/package.hjson.tpl
@@ -43,7 +43,7 @@
     "lint-fix": "eslint src --ext .ts --fix",
     "pre-commit": "npm-run-all pretty lint",
     "prepublishOnly": "yarn install; yarn build",
-    "pretty": "prettier -l \"src/**/*.ts\"",
+    "pretty": "prettier --check \"src/**/*.ts\"",
     "pretty-fix": "prettier --write \"src/**/*.ts\"",
     "test": "NODE_ENV=test jest --watch \"./src/\"",
     "test-ci": "NODE_ENV=test jest \"./src/\"",


### PR DESCRIPTION
## What this PR does / why we need it

Using `--check` instead of `--list-different` should make it clearer to folks who don't use `prettier` by default what the problem is and how to solve it.

## Jira ID

[DT-4452]

## Notes for reviewers

See also: https://github.com/getoutreach/devbase/pull/806

[DT-4452]: https://outreach-io.atlassian.net/browse/DT-4452?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ