### PR TITLE
fix: update default Node.js versions to 20.16.0

### DIFF
--- a/manifest.yaml
+++ b/manifest.yaml
@@ -177,14 +177,14 @@ arguments:
         - number
   versions.nodejs:
     description: Nodejs version to use for build tooling (e.g., semantic-release)
-    default: "20.12.2"
+    default: "20.16.0"
     schema:
       type:
         - string
         - number
   versions.grpcClients.nodejs:
     description: Nodejs version to use for gRPC clients
-    default: "20.8.0"
+    default: "20.16.0"
     schema:
       type:
         - string


### PR DESCRIPTION
## What this PR does / why we need it

This is needed in particular for the gRPC client, because at least one of the transitive dependencies will no longer install under Node.js 20.8.0.

I also upgraded the Node.js version for `semantic-release` because why not, might as well have fewer Node.js versions hanging around.

## Jira ID

[DT-4478]

[DT-4478]: https://outreach-io.atlassian.net/browse/DT-4478?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ