### PR TITLE
fix(gomod): always merge in toolchain changes

### DIFF
--- a/internal/plugin/merge.go
+++ b/internal/plugin/merge.go
@@ -134,6 +134,11 @@ func MergeGoMod(t *apiv1.TemplateFunctionExec) (string, error) { //nolint:funlen
 		return "", errors.Wrap(err, "failed to set go version")
 	}
 
+	// Always use the toolchain from the right hand go.mod
+	if err := leftMod.AddToolchainStmt(rightMod.Toolchain.Name); err != nil {
+		return "", errors.Wrap(err, "failed to set toolchain")
+	}
+
 	newBytes, err := leftMod.Format()
 	if err != nil {
 		return "", errors.Wrap(err, "failed to save generated go.mod")

--- a/templates/.snapshots/TestMergeGoMod-go.mod.tpl-go.mod.snapshot
+++ b/templates/.snapshots/TestMergeGoMod-go.mod.tpl-go.mod.snapshot
@@ -4,6 +4,8 @@ module github.com/getoutreach/stencil-golang
 
 go 1.22
 
+toolchain go1.22.6
+
 require (
 	github.com/blang/semver/v4 v4.0.0
 	github.com/getoutreach/gobox v1.90.2


### PR DESCRIPTION
## What this PR does / why we need it

Fixes the issue where `toolchain` wasn't updated when the Go version changed, because there's custom (plugin) code to merge the existing `go.mod` with the Stencil-generated one.


## Jira ID

[DT-4486]

[DT-4486]: https://outreach-io.atlassian.net/browse/DT-4486?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ