### PR TITLE
chore: fix ruby client.gemspec spaces

### DIFF
--- a/templates/api/clients/ruby/client.gemspec.tpl
+++ b/templates/api/clients/ruby/client.gemspec.tpl
@@ -23,6 +23,6 @@ Gem::Specification.new do |spec|
   spec.add_dependency 'grpc', '~> 1.38'
   spec.add_development_dependency 'rake'
   ## <<Stencil::Block(extraGemSpec)>>
-  {{ file.Block "extraGemSpec" }}
+{{ file.Block "extraGemSpec" }}
   ## <</Stencil::Block>>
 end


### PR DESCRIPTION
<!--
  !!!! README !!!! Please fill this out.

  Please follow conventional commit naming conventions:

  https://www.conventionalcommits.org/en/v1.0.0/#summary
-->

Please read [CONTRIBUTING.md](CONTRIBUTING.md) for additional information on contributing to this repository!

<!-- A short description of what your PR does and what it solves. -->
## What this PR does / why we need it

When `file.Block` is empty, the spaces are left there. IDEs +`make fmt` are then trying to delete those spaces which creates a change differing from the stencil template. This small fix corrects that.

<!-- <<Stencil::Block(jiraPrefix)>> -->

## Jira ID

[XX-XX]

<!-- <</Stencil::Block>> -->

<!-- Notes that may be helpful for anyone reviewing this PR -->
## Notes for your reviewers

<!-- <<Stencil::Block(custom)>> -->

<!-- <</Stencil::Block>> -->
