### PR TITLE
fix(ruby_client): align one file with the RuboCop rules

### DIFF
--- a/templates/api/clients/ruby/client.gemspec.tpl
+++ b/templates/api/clients/ruby/client.gemspec.tpl
@@ -16,7 +16,7 @@ Gem::Specification.new do |spec|
   spec.metadata["github_repo"] = "ssh://github.com/getoutreach/{{ .Config.Name }}"
 
   spec.required_ruby_version = Gem::Requirement.new(">= {{ stencil.Arg "versions.grpcClients.ruby" }}")
-  spec.files         = Dir.chdir(File.expand_path('..', __FILE__)) do
+  spec.files = Dir.chdir(File.expand_path(__dir__)) do
     `git ls-files -z`.split("\x0").reject { |f| f.match(%r{^(test|spec|features)/}) }
   end
   spec.require_paths = ["lib", "lib/{{ .Config.Name }}_client"]


### PR DESCRIPTION
<!-- A short description of what your PR does and what it solves. -->
## What this PR does / why we need it
Small tweak to align with a [rule](https://www.rubydoc.info/gems/rubocop/RuboCop/Cop/Style/ExpandPathArguments) enforced by the VSCode RuboCop extension.

<!-- <<Stencil::Block(jiraPrefix)>> -->

## Jira ID

[XX-XX]

<!-- <</Stencil::Block>> -->

<!-- Notes that may be helpful for anyone reviewing this PR -->
## Notes for your reviewers

<!-- <<Stencil::Block(custom)>> -->

<!-- <</Stencil::Block>> -->
