### PR TITLE
fix: go.stanza prefers a full version

### DIFF
--- a/manifest.yaml
+++ b/manifest.yaml
@@ -211,7 +211,7 @@ arguments:
       type: boolean
   go.stanza:
     description: Go stanza version
-    default: "1.22"
+    default: "1.22.0"
     schema:
       type:
         - string

--- a/templates/.snapshots/TestBasicGoMod-go.mod.tpl-go.mod.snapshot
+++ b/templates/.snapshots/TestBasicGoMod-go.mod.tpl-go.mod.snapshot
@@ -1,6 +1,6 @@
 (*codegen.File)(module github.com/getoutreach/testing
 
-go 1.22
+go 1.22.0
 
 toolchain go1.22.6
 

--- a/templates/.snapshots/TestMergeGoMod-go.mod.tpl-go.mod.snapshot
+++ b/templates/.snapshots/TestMergeGoMod-go.mod.tpl-go.mod.snapshot
@@ -2,7 +2,7 @@
 
 module github.com/getoutreach/stencil-golang
 
-go 1.22
+go 1.22.0
 
 toolchain go1.22.6
 


### PR DESCRIPTION
## What this PR does / why we need it

Recent Dependabot PRs have been failing with the following diff reporting from `go mod tidy`:

```diff
-go 1.22
+go 1.22.0
```

This adjusts the default so that running `stencil` and merging Dependabot PRs doesn't cause the `go` directive to constantly change.