### PR TITLE
feat: update AIR config to watch e2e tests and build them

### DIFF
--- a/templates/.air.toml.tpl
+++ b/templates/.air.toml.tpl
@@ -7,7 +7,7 @@ root = "."
 
 [build]
 # Just plain old shell command. You could use `make` as well.
-cmd = "make"
+cmd = "make devspace"
 
 # Binary file yields from `cmd`.
 bin = ".bootstrap/shell/air-runner.sh"
@@ -17,6 +17,9 @@ include_ext = ["go", "tpl", "tmpl", "html"]
 
 # Ignore these filename extensions or directories.
 exclude_dir = ["api", "node_modules", "vendor"]
+
+# do not exclude anything (also tests, as by default)
+exclude_regex = []
 
 # Watch these directories if you specified.
 include_dir = []


### PR DESCRIPTION
<!--
  !!!! README !!!! Please fill this out.

  Please follow conventional commit naming conventions:

  https://www.conventionalcommits.org/en/v1.0.0/#summary
-->

Please read [CONTRIBUTING.md](CONTRIBUTING.md) for additional information on contributing to this repository!

<!-- A short description of what your PR does and what it solves. -->
## What this PR does / why we need it

After months of struggling, I have a simple solution. 

**Problem**: When working with devenv and binary sync, changes in e2e tests are not watched and man must manually call `make devspace` after each test change to build a new e2e binary which is then synced into the pod. When building the binary, e2e tests binary is also not built by default.

**Solution**: configure [AIR](https://github.com/air-verse/air) to:

- watch also files with `_test.go` suffix (they are by default [excluded](https://github.com/air-verse/air/blob/master/runner/config.go#L229))
- build all binaries suitable for devenv not with `make` but with `make devspace`

I don't see any harm to rebuild a binary when any test file is changed.

This PR changes the template for AIR.

<!-- <<Stencil::Block(jiraPrefix)>> -->

## Jira ID

[XX-XX]

<!-- <</Stencil::Block>> -->

<!-- Notes that may be helpful for anyone reviewing this PR -->
## Notes for your reviewers

<!-- <<Stencil::Block(custom)>> -->

<!-- <</Stencil::Block>> -->
