### PR TITLE
feat: sync graphql schema in binary sync mode

### DIFF
--- a/templates/.snapshots/TestDevspaceYaml-devspace.yaml.tpl-devspace.yaml.snapshot
+++ b/templates/.snapshots/TestDevspaceYaml-devspace.yaml.tpl-devspace.yaml.snapshot
@@ -435,6 +435,14 @@ profiles:
           disableDownload: true
           waitInitialSync: true
       - op: add
+        path: dev.app.sync
+        value:
+            path: ./internal/graphql/schema:${DEV_CONTAINER_WORKDIR}/internal/graphql/schema
+            waitInitialSync: true
+            initialSync: mirrorLocal
+            disableDownload: true
+            printLogs: true
+      - op: add
         path: hooks
         value:
           name: reset-dev

--- a/templates/devspace.yaml.tpl
+++ b/templates/devspace.yaml.tpl
@@ -459,6 +459,14 @@ profiles:
           disableDownload: true
           waitInitialSync: true
       - op: add
+        path: dev.app.sync
+        value:
+            path: ./internal/graphql/schema:${DEV_CONTAINER_WORKDIR}/internal/graphql/schema
+            waitInitialSync: true
+            initialSync: mirrorLocal
+            disableDownload: true
+            printLogs: true
+      - op: add
         path: hooks
         value:
           name: reset-dev


### PR DESCRIPTION
<!--
  !!!! README !!!! Please fill this out.

  Please follow conventional commit naming conventions:

  https://www.conventionalcommits.org/en/v1.0.0/#summary
-->

Please read [CONTRIBUTING.md](CONTRIBUTING.md) for additional information on contributing to this repository!

<!-- A short description of what your PR does and what it solves. -->
## What this PR does / why we need it

**Problem**: When using devspace in binary sync mode (`devenv apps run -b .`), the graphql schema is not synced. When we're trying to [refresh the supergraph](https://app.glean.com/knowledge/answers/419) at gazelle, it [fails](https://github.com/getoutreach/stencil-graphql/blob/7b39fdacefa8bd3fbe1428975ce8ac9610db3c95/pkg/handler/handler.go#L181-L225), because graphql files are not present in the pod.

**Solution**: Sync graphql schema into the devspace pod for binary sync mode.

<!-- <<Stencil::Block(jiraPrefix)>> -->

## Jira ID

[XX-XX]

<!-- <</Stencil::Block>> -->

<!-- Notes that may be helpful for anyone reviewing this PR -->
## Notes for your reviewers

<!-- <<Stencil::Block(custom)>> -->

<!-- <</Stencil::Block>> -->
