### PR TITLE
feat(devspace): add module hook for binary sync patches

### DIFF
--- a/docs/module-hooks.md
+++ b/docs/module-hooks.md
@@ -203,6 +203,42 @@ Extra configuration jsonnet files to merge into the application config.
 {{ stencil.AddToModuleHook "github.com/getoutreach/stencil-golang" "app.config.jsonnet/config" (list $myConfig) }}
 ```
 
+### `devspace.binarySyncDevPatches`
+
+**Type**:
+
+```json
+[
+  {
+    op: string
+    path: string
+    value: [ key: value ]
+  }
+]
+```
+
+**File**: `devspace.yaml.tpl`
+
+Extra [devspace patches](https://www.devspace.sh/docs/configuration/profiles/patches)
+to use when using the binary sync feature of `devenv`.
+
+Example:
+
+```tpl
+{{- define "syncFooBarFolderForBinarySync" }}
+- op: add
+  path: dev.app.sync
+  value:
+    path: ./foo/bar:${DEV_CONTAINER_WORKDIR}/foo/bar
+    waitInitialSync: true
+    initialSync: mirrorLocal
+    disableDownload: true
+    printLogs: true
+{{- end }}
+
+{{ stencil.AddToModuleHook "github.com/getoutreach/stencil-golang" "devspace.binarySyncDevPatches" (stencil.ApplyTemplate "syncFooBarFolderForBinarySync" | fromYaml) }}
+```
+
 ### `devspace.profiles`
 
 **Type**:

--- a/docs/module-hooks.md
+++ b/docs/module-hooks.md
@@ -207,7 +207,7 @@ Extra configuration jsonnet files to merge into the application config.
 
 **Type**:
 
-```json
+```yaml
 [
   {
     op: string

--- a/docs/module-hooks.md
+++ b/docs/module-hooks.md
@@ -236,7 +236,7 @@ Example:
     printLogs: true
 {{- end }}
 
-{{ stencil.AddToModuleHook "github.com/getoutreach/stencil-golang" "devspace.binarySyncDevPatches" (stencil.ApplyTemplate "syncFooBarFolderForBinarySync" | fromYaml) }}
+{{ stencil.AddToModuleHook "github.com/getoutreach/stencil-golang" "devspace.binarySyncDevPatches" (stencil.ApplyTemplate "syncFooBarFolderForBinarySync" | fromYaml | list) }}
 ```
 
 ### `devspace.profiles`

--- a/templates/.snapshots/TestDevspaceYaml-devspace.yaml.tpl-devspace.yaml.snapshot
+++ b/templates/.snapshots/TestDevspaceYaml-devspace.yaml.tpl-devspace.yaml.snapshot
@@ -435,14 +435,6 @@ profiles:
           disableDownload: true
           waitInitialSync: true
       - op: add
-        path: dev.app.sync
-        value:
-            path: ./internal/graphql/schema:${DEV_CONTAINER_WORKDIR}/internal/graphql/schema
-            waitInitialSync: true
-            initialSync: mirrorLocal
-            disableDownload: true
-            printLogs: true
-      - op: add
         path: hooks
         value:
           name: reset-dev

--- a/templates/devspace.yaml.tpl
+++ b/templates/devspace.yaml.tpl
@@ -458,14 +458,9 @@ profiles:
           printLogs: true
           disableDownload: true
           waitInitialSync: true
-      - op: add
-        path: dev.app.sync
-        value:
-            path: ./internal/graphql/schema:${DEV_CONTAINER_WORKDIR}/internal/graphql/schema
-            waitInitialSync: true
-            initialSync: mirrorLocal
-            disableDownload: true
-            printLogs: true
+{{- range (stencil.GetModuleHook "devspace.binarySyncDevPatches") }}
+{{ toYaml . | indent 6 }}
+{{- end }}
       - op: add
         path: hooks
         value:


### PR DESCRIPTION
## What this PR does / why we need it

Reverts #551 and replaces it with a module hook. The needs of private Stencil modules should not leak into public Stencil modules.

## Jira ID

[DT-4541]

[DT-4541]: https://outreach-io.atlassian.net/browse/DT-4541?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ