### PR TITLE
fix(go): sync default Go stanza with minor default Go version

### DIFF
--- a/manifest.yaml
+++ b/manifest.yaml
@@ -211,7 +211,7 @@ arguments:
       type: boolean
   go.stanza:
     description: Go stanza version
-    default: "1.22.0"
+    default: "1.23.0"
     schema:
       type:
         - string

--- a/templates/.snapshots/TestBasicGoMod-go.mod.tpl-go.mod.snapshot
+++ b/templates/.snapshots/TestBasicGoMod-go.mod.tpl-go.mod.snapshot
@@ -1,6 +1,6 @@
 (*codegen.File)(module github.com/getoutreach/testing
 
-go 1.22.0
+go 1.23.0
 
 toolchain go1.23.3
 

--- a/templates/.snapshots/TestMergeGoMod-go.mod.tpl-go.mod.snapshot
+++ b/templates/.snapshots/TestMergeGoMod-go.mod.tpl-go.mod.snapshot
@@ -2,7 +2,7 @@
 
 module github.com/getoutreach/stencil-golang
 
-go 1.22.0
+go 1.23.0
 
 toolchain go1.23.3
 


### PR DESCRIPTION
## What this PR does / why we need it

This fixes Dependabot PRs to be automatically mergeable.

## Jira ID

[DT-4533]

[DT-4533]: https://outreach-io.atlassian.net/browse/DT-4533?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ