### PR TITLE
fix(golangci-lint): resolve govet shadow config warning

### DIFF
--- a/scripts/golangci.yml
+++ b/scripts/golangci.yml
@@ -7,7 +7,8 @@ linters-settings:
   errcheck:
     check-blank: true
   govet:
-    check-shadowing: true
+    enable:
+      - shadow
   revive:
     rules:
       # Enable the default golint rules. We must include these because

--- a/templates/.snapshots/TestRenderGolangcilintYaml-scripts-golangci.yml.tpl-scripts-golangci.yml.snapshot
+++ b/templates/.snapshots/TestRenderGolangcilintYaml-scripts-golangci.yml.tpl-scripts-golangci.yml.snapshot
@@ -7,7 +7,8 @@ linters-settings:
   errcheck:
     check-blank: true
   govet:
-    check-shadowing: true
+    enable:
+      - shadow
   revive:
     rules:
       # Enable the default golint rules. We must include these because

--- a/templates/scripts/golangci.yml.tpl
+++ b/templates/scripts/golangci.yml.tpl
@@ -7,7 +7,8 @@ linters-settings:
   errcheck:
     check-blank: true
   govet:
-    check-shadowing: true
+    enable:
+      - shadow
   revive:
     rules:
       # Enable the default golint rules. We must include these because


### PR DESCRIPTION
## What this PR does / why we need it

Resolves the following warning:

> The configuration option `linters.govet.check-shadowing` is deprecated. Please enable `shadow` instead, if you are not using `enable-all`.

We are not using `enable-all`.