### PR TITLE
fix(ruby): sync bundler version with upstream

### DIFF
--- a/templates/api/clients/ruby/Gemfile.lock.tpl
+++ b/templates/api/clients/ruby/Gemfile.lock.tpl
@@ -24,4 +24,4 @@ DEPENDENCIES
   rake
 
 BUNDLED WITH
-   2.2.29
+   2.3.26


### PR DESCRIPTION
## What this PR does / why we need it

Upstream uses a newer version of Bundler, which causes conflicts in CI.