### PR TITLE
feat: stencil blocks around arch+os in .goreleaser.yml

### DIFF
--- a/templates/.goreleaser.yml.tpl
+++ b/templates/.goreleaser.yml.tpl
@@ -16,11 +16,27 @@ builds:
     id: &name {{ $cmdName }}
     binary: *name
     goos:
+      {{- $goosBlockName := (printf "%vGoos" ($cmdName | replace "-" "" | replace "_" "")) }}
+      ## <<Stencil::Block({{ $goosBlockName }})>>
+      {{- if not (empty (file.Block $goosBlockName)) }}
+      {{ (file.Block $goosBlockName) | trim }}
+      {{- else }}
+      ## Ability to build assets for those OS: linux, darwin
       - linux
       - darwin
+      {{- end }}
+      ## <</Stencil::Block>>
     goarch:
+      {{- $goarchBlockName := (printf "%vGoarch" ($cmdName | replace "-" "" | replace "_" "")) }}
+      ## <<Stencil::Block({{ $goarchBlockName }})>>
+      {{- if not (empty (file.Block $goarchBlockName)) }}
+      {{ (file.Block $goarchBlockName) | trim }}
+      {{- else }}
+      ## Ability to build assets for those architectures: amd64, arm64
       - amd64
       - arm64
+      {{- end }}
+      ## <</Stencil::Block>>
     ldflags:
       - '-w -s -X "github.com/getoutreach/gobox/pkg/app.Version=v{{ "{{" }} .Version {{ "}}" }}"'
       {{- if not $opts.delibird }}

--- a/templates/.snapshots/TestGoreleaserYml-.goreleaser.yml.tpl-.goreleaser.yml.snapshot
+++ b/templates/.snapshots/TestGoreleaserYml-.goreleaser.yml.tpl-.goreleaser.yml.snapshot
@@ -7,11 +7,17 @@ builds:
     id: &name cmd1
     binary: *name
     goos:
+      ## <<Stencil::Block(cmd1Goos)>>
+      ## Ability to build assets for those OS: linux, darwin
       - linux
       - darwin
+      ## <</Stencil::Block>>
     goarch:
+      ## <<Stencil::Block(cmd1Goarch)>>
+      ## Ability to build assets for those architectures: amd64, arm64
       - amd64
       - arm64
+      ## <</Stencil::Block>>
     ldflags:
       - '-w -s -X "github.com/getoutreach/gobox/pkg/app.Version=v{{ .Version }}"'
       - '-X "main.HoneycombTracingKey={{ .Env.HONEYCOMB_APIKEY }}"'
@@ -25,11 +31,17 @@ builds:
     id: &name cmd2
     binary: *name
     goos:
+      ## <<Stencil::Block(cmd2Goos)>>
+      ## Ability to build assets for those OS: linux, darwin
       - linux
       - darwin
+      ## <</Stencil::Block>>
     goarch:
+      ## <<Stencil::Block(cmd2Goarch)>>
+      ## Ability to build assets for those architectures: amd64, arm64
       - amd64
       - arm64
+      ## <</Stencil::Block>>
     ldflags:
       - '-w -s -X "github.com/getoutreach/gobox/pkg/app.Version=v{{ .Version }}"'
       - '-X "main.HoneycombTracingKey={{ .Env.HONEYCOMB_APIKEY }}"'
@@ -43,11 +55,17 @@ builds:
     id: &name cmd3-sub1
     binary: *name
     goos:
+      ## <<Stencil::Block(cmd3sub1Goos)>>
+      ## Ability to build assets for those OS: linux, darwin
       - linux
       - darwin
+      ## <</Stencil::Block>>
     goarch:
+      ## <<Stencil::Block(cmd3sub1Goarch)>>
+      ## Ability to build assets for those architectures: amd64, arm64
       - amd64
       - arm64
+      ## <</Stencil::Block>>
     ldflags:
       - '-w -s -X "github.com/getoutreach/gobox/pkg/app.Version=v{{ .Version }}"'
       - '-X "main.HoneycombTracingKey={{ .Env.HONEYCOMB_APIKEY }}"'
@@ -61,11 +79,17 @@ builds:
     id: &name cmd3-sub2
     binary: *name
     goos:
+      ## <<Stencil::Block(cmd3sub2Goos)>>
+      ## Ability to build assets for those OS: linux, darwin
       - linux
       - darwin
+      ## <</Stencil::Block>>
     goarch:
+      ## <<Stencil::Block(cmd3sub2Goarch)>>
+      ## Ability to build assets for those architectures: amd64, arm64
       - amd64
       - arm64
+      ## <</Stencil::Block>>
     ldflags:
       - '-w -s -X "github.com/getoutreach/gobox/pkg/app.Version=v{{ .Version }}"'
       - '-X "main.HoneycombTracingKey={{ .Env.HONEYCOMB_APIKEY }}"'
@@ -79,11 +103,17 @@ builds:
     id: &name cmd4_sub1
     binary: *name
     goos:
+      ## <<Stencil::Block(cmd4sub1Goos)>>
+      ## Ability to build assets for those OS: linux, darwin
       - linux
       - darwin
+      ## <</Stencil::Block>>
     goarch:
+      ## <<Stencil::Block(cmd4sub1Goarch)>>
+      ## Ability to build assets for those architectures: amd64, arm64
       - amd64
       - arm64
+      ## <</Stencil::Block>>
     ldflags:
       - '-w -s -X "github.com/getoutreach/gobox/pkg/app.Version=v{{ .Version }}"'
       - '-X "main.HoneycombTracingKey={{ .Env.HONEYCOMB_APIKEY }}"'


### PR DESCRIPTION
<!--
  !!!! README !!!! Please fill this out.

  Please follow conventional commit naming conventions:

  https://www.conventionalcommits.org/en/v1.0.0/#summary
-->

Please read [CONTRIBUTING.md](CONTRIBUTING.md) for additional information on contributing to this repository!

<!-- A short description of what your PR does and what it solves. -->
## What this PR does / why we need it

Discussed in [Slack](https://outreach-hq.slack.com/archives/C01CAR6GVPD/p1733906223077049?thread_ts=1733820097.550999&cid=C01CAR6GVPD). Not all services needed both architectures to be built. This makes ability to define it for each of the service individually.

The block set's the default and preserves if there's something else.

It'd be also worth it to think about dropping arm64+darwin as only a few repos/services need assets to be built (for example: clerkcli). 

Tested locally.

<!-- <<Stencil::Block(jiraPrefix)>> -->

## Jira ID

[XX-XX]

<!-- <</Stencil::Block>> -->

<!-- Notes that may be helpful for anyone reviewing this PR -->
## Notes for your reviewers

<!-- <<Stencil::Block(custom)>> -->

<!-- <</Stencil::Block>> -->
