### PR TITLE
fix(deps): update orgservice to 1.148.6 to update k8s dependency

### DIFF
--- a/templates/_helpers.tpl
+++ b/templates/_helpers.tpl
@@ -132,7 +132,7 @@ go:
 - name: google.golang.org/grpc
   version: v1.37.0
 - name: github.com/getoutreach/orgservice
-  version: v1.63.0
+  version: v1.148.6
   # Used for grpcx
 - name: github.com/getoutreach/services
   version: v1.175.1


### PR DESCRIPTION
## What this PR does / why we need it

Does what it says on the tin.