### PR TITLE
fix(vscode): disable autoupdating Go tools to avoid mismatches

### DIFF
--- a/templates/.snapshots/TestGRPCServerRPC-internal-appName-rpc-rpc.go.tpl-internal-testing-rpc.go.snapshot
+++ b/templates/.snapshots/TestGRPCServerRPC-internal-appName-rpc-rpc.go.tpl-internal-testing-rpc.go.snapshot
@@ -1,5 +1,5 @@
 (*codegen.File)(
-// Copyright 2024 Outreach Corporation. All Rights Reserved.
+// Copyright 2025 Outreach Corporation. All Rights Reserved.
 
 // Description: This file contains the gRPC server passthrough implementation for the
 // testing API defined in api/testing.proto. The concrete implementation

--- a/templates/.snapshots/TestRenderAPIGoSuccess-api-api.go.tpl-api-testing.go.snapshot
+++ b/templates/.snapshots/TestRenderAPIGoSuccess-api-api.go.tpl-api-testing.go.snapshot
@@ -1,5 +1,5 @@
 (*codegen.File)(<nil>
-// Copyright 2024 Outreach Corporation. All Rights Reserved.
+// Copyright 2025 Outreach Corporation. All Rights Reserved.
 
 // Description: This file defines the gRPC server service interface for
 // testing.

--- a/templates/.snapshots/TestRenderDeploymentConfig-deployments-appname-app.config.jsonnet.tpl-deployments-testing-testing.config.jsonnet.snapshot
+++ b/templates/.snapshots/TestRenderDeploymentConfig-deployments-appname-app.config.jsonnet.tpl-deployments-testing-testing.config.jsonnet.snapshot
@@ -1,4 +1,4 @@
-(*codegen.File)(// Copyright 2024 Outreach Corporation. All Rights Reserved.
+(*codegen.File)(// Copyright 2025 Outreach Corporation. All Rights Reserved.
 //
 // Managed: true
 

--- a/templates/.snapshots/TestRenderDeploymentJsonnet-deployments-appname-app.jsonnet.tpl-deployments-testing-testing.jsonnet.snapshot
+++ b/templates/.snapshots/TestRenderDeploymentJsonnet-deployments-appname-app.jsonnet.tpl-deployments-testing-testing.jsonnet.snapshot
@@ -1,5 +1,5 @@
 (*codegen.File)(
-// Copyright 2024 Outreach Corporation. All Rights Reserved.
+// Copyright 2025 Outreach Corporation. All Rights Reserved.
 //
 // Managed: true
 

--- a/templates/.snapshots/TestRenderDeploymentJsonnetWithHPA-deployments-appname-app.jsonnet.tpl-deployments-testing-testing.jsonnet.snapshot
+++ b/templates/.snapshots/TestRenderDeploymentJsonnetWithHPA-deployments-appname-app.jsonnet.tpl-deployments-testing-testing.jsonnet.snapshot
@@ -1,5 +1,5 @@
 (*codegen.File)(
-// Copyright 2024 Outreach Corporation. All Rights Reserved.
+// Copyright 2025 Outreach Corporation. All Rights Reserved.
 //
 // Managed: true
 

--- a/templates/.snapshots/TestRenderDeploymentJsonnet_Canary-deployments-appname-app.jsonnet.tpl-deployments-testing-testing.jsonnet.snapshot
+++ b/templates/.snapshots/TestRenderDeploymentJsonnet_Canary-deployments-appname-app.jsonnet.tpl-deployments-testing-testing.jsonnet.snapshot
@@ -1,5 +1,5 @@
 (*codegen.File)(
-// Copyright 2024 Outreach Corporation. All Rights Reserved.
+// Copyright 2025 Outreach Corporation. All Rights Reserved.
 //
 // Managed: true
 

--- a/templates/.snapshots/TestRenderDeploymentJsonnet_Canary_emptyServiceActivities-deployments-appname-app.jsonnet.tpl-deployments-testing-testing.jsonnet.snapshot
+++ b/templates/.snapshots/TestRenderDeploymentJsonnet_Canary_emptyServiceActivities-deployments-appname-app.jsonnet.tpl-deployments-testing-testing.jsonnet.snapshot
@@ -1,5 +1,5 @@
 (*codegen.File)(
-// Copyright 2024 Outreach Corporation. All Rights Reserved.
+// Copyright 2025 Outreach Corporation. All Rights Reserved.
 //
 // Managed: true
 

--- a/templates/.snapshots/TestRenderDeploymentOverride-deployments-appname-app.override.jsonnet.tpl-deployments-testing-testing.override.jsonnet.snapshot
+++ b/templates/.snapshots/TestRenderDeploymentOverride-deployments-appname-app.override.jsonnet.tpl-deployments-testing-testing.override.jsonnet.snapshot
@@ -1,4 +1,4 @@
-(*codegen.File)(// Copyright 2024 Outreach Corporation. All Rights Reserved.
+(*codegen.File)(// Copyright 2025 Outreach Corporation. All Rights Reserved.
 //
 // Description: This file is automatically merged into the 'testing.jsonnet' file.
 // Configuration should go into the 'testing.config.jsonnet' file, or in the relevant

--- a/templates/.snapshots/TestUseKIAMFalse-deployments-appname-app.jsonnet.tpl-deployments-testing-testing.jsonnet.snapshot
+++ b/templates/.snapshots/TestUseKIAMFalse-deployments-appname-app.jsonnet.tpl-deployments-testing-testing.jsonnet.snapshot
@@ -1,5 +1,5 @@
 (*codegen.File)(
-// Copyright 2024 Outreach Corporation. All Rights Reserved.
+// Copyright 2025 Outreach Corporation. All Rights Reserved.
 //
 // Managed: true
 

--- a/templates/.vscode/settings.json.tpl
+++ b/templates/.vscode/settings.json.tpl
@@ -12,6 +12,11 @@
   "go.alternateTools": {
     "golangci-lint": "${workspaceFolder}/.bootstrap/shell/vscode/golang-linters.sh"
   },
+  // This is disabled because it causes version mismatches between the
+  // tools used/installed by asdf / stencil, and the ones updated by VSCode.
+  // In particular, this is a problem with newer versions of golangci-lint
+  // incompatible with older versions of Go.
+  "go.toolsManagement.autoUpdate": false,
   "go.buildTags": "or_dev",
   "go.testTags": "or_test,or_int,or_e2e",
   "files.trimTrailingWhitespace": true,


### PR DESCRIPTION
## What this PR does / why we need it

From the comment I put in the settings file:

> This is disabled because it causes version mismatches between the tools used/installed by `asdf` / `stencil` templates, and the ones updated by VSCode. In particular, this is a problem with newer versions of `golangci-lint` incompatible with older versions of Go.

## Jira ID

[DT-4570]

## Notes for your reviewers

Requires #565 to be merged first


[DT-4570]: https://outreach-io.atlassian.net/browse/DT-4570?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ