### PR TITLE
fix(helpers): update kubernetes.groups dependencies to non-vulnerable versions

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -16,4 +16,7 @@ indent_size  = 2
 [*.tpl]
 indent_style = space
 indent_size =  2
+
+[*.go.tpl]
+indent_style = tab
 ## <</Stencil::Block>>

--- a/templates/_helpers.tpl
+++ b/templates/_helpers.tpl
@@ -149,11 +149,11 @@ go:
 
 {{- if stencil.Arg "kubernetes.groups" }}
 - name: k8s.io/apimachinery
-  version: v0.23.0
+  version: v0.30.8
 - name: k8s.io/client-go
-  version: v0.23.0
+  version: v0.30.8
 - name: sigs.k8s.io/controller-runtime
-  version: v0.9.6
+  version: v0.18.6
 {{- end }}
 
 {{- range stencil.GetModuleHook "go_modules" }}

--- a/templates/api/kubernetes/version.go.tpl
+++ b/templates/api/kubernetes/version.go.tpl
@@ -10,7 +10,7 @@
 package {{ .version }}
 
 //nolint:lll //Why: Long shell script
-//go:generate /usr/bin/env bash -c "pushd ../../..{{if not (empty .package)}}/..{{end}} >/dev/null 2>&1 && ./scripts/shell-wrapper.sh gobin.sh sigs.k8s.io/controller-tools/cmd/controller-gen@v0.14.0 object paths=./api/k8s/{{ .package }}/{{ .version }} && popd >/dev/null 2>&1"
+//go:generate /usr/bin/env bash -c "pushd ../../..{{if not (empty .package)}}/..{{end}} >/dev/null 2>&1 && ./scripts/shell-wrapper.sh gobin.sh sigs.k8s.io/controller-tools/cmd/controller-gen@v0.15.0 object paths=./api/k8s/{{ .package }}/{{ .version }} && popd >/dev/null 2>&1"
 {{ end }}
 
 {{- range $g := stencil.Arg "kubernetes.groups" }}

--- a/templates/internal/appName/k8s/activity.go.tpl
+++ b/templates/internal/appName/k8s/activity.go.tpl
@@ -31,7 +31,7 @@ import (
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/controller"
 	metrics "sigs.k8s.io/controller-runtime/pkg/metrics/server"
-	"sigs.k8s.io/controller-runtime/pkg/webhook
+	"sigs.k8s.io/controller-runtime/pkg/webhook"
 	"github.com/pkg/errors"
 	"k8s.io/apimachinery/pkg/runtime"
 	clientgoscheme "k8s.io/client-go/kubernetes/scheme"


### PR DESCRIPTION
## What this PR does / why we need it

Update the generated code when the `kubernetes.groups` in `service.yaml` is configured, when using newer, non-vulnerable versions of Kubernetes libraries.

## Jira ID

[DT-4549]

[DT-4549]: https://outreach-io.atlassian.net/browse/DT-4549?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ