### PR TITLE
fix(nodejs): remove rimraf as a devDependency

### DIFF
--- a/templates/.snapshots/TestRenderDependabot-.github-dependabot.yml.tpl-.github-dependabot.yml.snapshot
+++ b/templates/.snapshots/TestRenderDependabot-.github-dependabot.yml.tpl-.github-dependabot.yml.snapshot
@@ -48,7 +48,6 @@ updates:
       - dependency-name: "jest"
       - dependency-name: "npm-run-all"
       - dependency-name: "prettier"
-      - dependency-name: "rimraf"
       - dependency-name: "ts-jest"
       - dependency-name: "ts-node"
       - dependency-name: "tsconfig-paths"

--- a/templates/_helpers.tpl
+++ b/templates/_helpers.tpl
@@ -209,8 +209,6 @@ nodejs:
     version: ^4.1.5
   - name: prettier
     version: ^3.0.0
-  - name: rimraf
-    version: ^3.0.2
   - name: ts-jest
     version: ^26.4.4
   - name: ts-node

--- a/templates/api/clients/node/package.hjson.tpl
+++ b/templates/api/clients/node/package.hjson.tpl
@@ -38,7 +38,7 @@
     // <</Stencil::Block>>
     "build": "npm-run-all clean tsc",
     "ci": "npm-run-all pretty lint test-ci",
-    "clean": "rimraf dist",
+    "clean": "rm -rf dist",
     "lint": "eslint src --ext .ts",
     "lint-fix": "eslint src --ext .ts --fix",
     "pre-commit": "npm-run-all pretty lint",


### PR DESCRIPTION
## What this PR does / why we need it

We only officially support macOS and Linux, both of which have working `rm -rf` commands. If we supported Windows (outside of WSL, and even only marginally at that currently), then we'd have to consider doing something like `node -e 'fs.rmSync("dist", {force: true, recursive: true})'`