### PR TITLE
fix: update gRPC client Ruby version to 3.1.5

### DIFF
--- a/manifest.yaml
+++ b/manifest.yaml
@@ -191,7 +191,7 @@ arguments:
         - number
   versions.grpcClients.ruby:
     description: Ruby version to use for gRPC clients
-    default: "3.1.3"
+    default: "3.1.5"
     schema:
       type:
         - string

--- a/templates/.snapshots/TestIncludeRubyToolVersionsIfRubyGRPCClient-testdata-tool-versions-ruby-.tool-versions.tpl-testdata-tool-versions-ruby-.tool-versions.snapshot
+++ b/templates/.snapshots/TestIncludeRubyToolVersionsIfRubyGRPCClient-testdata-tool-versions-ruby-.tool-versions.tpl-testdata-tool-versions-ruby-.tool-versions.snapshot
@@ -1,4 +1,4 @@
 (*codegen.File)(
 - name: ruby
-  version: 3.1.3
+  version: 3.1.5
 )

--- a/templates/.snapshots/TestIncludeRubyToolVersionsIfRubyGRPCClientLibrary-testdata-tool-versions-ruby-.tool-versions.tpl-testdata-tool-versions-ruby-.tool-versions.snapshot
+++ b/templates/.snapshots/TestIncludeRubyToolVersionsIfRubyGRPCClientLibrary-testdata-tool-versions-ruby-.tool-versions.tpl-testdata-tool-versions-ruby-.tool-versions.snapshot
@@ -1,4 +1,4 @@
 (*codegen.File)(
 - name: ruby
-  version: 3.1.3
+  version: 3.1.5
 )


### PR DESCRIPTION
## What this PR does / why we need it

Does what it says on the tin.

## Jira ID

[DT-4746]

[DT-4746]: https://outreach-io.atlassian.net/browse/DT-4746?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ