### PR TITLE
feat: add conditional support for `urfave/cli/v3`

### DIFF
--- a/manifest.yaml
+++ b/manifest.yaml
@@ -203,6 +203,14 @@ arguments:
       type:
         - string
         - number
+  versions.urfave-cli:
+    description: major urfave/cli version to use
+    default: "v2"
+    schema:
+      type: string
+      enum:
+        - v2
+        - v3
   enableCgo:
     from: github.com/getoutreach/devbase
   disableGrpcGeneration:

--- a/templates/.snapshots/TestBasicGoMod-go.mod.tpl-go.mod.snapshot
+++ b/templates/.snapshots/TestBasicGoMod-go.mod.tpl-go.mod.snapshot
@@ -5,6 +5,6 @@ go 1.23.0
 toolchain go1.23.4
 
 require (
-	github.com/getoutreach/gobox v1.104.0
+	github.com/getoutreach/gobox v1.107.0
 	github.com/getoutreach/stencil-golang/pkg v0.0.0-20250109193043-fa44ea640e7e
 ))

--- a/templates/.snapshots/TestGoModStanzaVersion-go.mod.tpl-go.mod.snapshot
+++ b/templates/.snapshots/TestGoModStanzaVersion-go.mod.tpl-go.mod.snapshot
@@ -5,6 +5,6 @@ go 1.19
 toolchain go1.23.4
 
 require (
-	github.com/getoutreach/gobox v1.104.0
+	github.com/getoutreach/gobox v1.107.0
 	github.com/getoutreach/stencil-golang/pkg v0.0.0-20250109193043-fa44ea640e7e
 ))

--- a/templates/.snapshots/TestMergeGoMod-go.mod.tpl-go.mod.snapshot
+++ b/templates/.snapshots/TestMergeGoMod-go.mod.tpl-go.mod.snapshot
@@ -8,7 +8,7 @@ toolchain go1.23.4
 
 require (
 	github.com/blang/semver/v4 v4.0.0
-	github.com/getoutreach/gobox v1.104.0
+	github.com/getoutreach/gobox v1.107.0
 	github.com/getoutreach/stencil v1.28.0-rc.2
 	github.com/pkg/errors v0.9.1
 	github.com/sirupsen/logrus v1.9.0

--- a/templates/.snapshots/TestUrfaveCLIV2-cmd-main_cli.go.tpl-cmd-cmd1-cmd1.go.snapshot
+++ b/templates/.snapshots/TestUrfaveCLIV2-cmd-main_cli.go.tpl-cmd-cmd1-cmd1.go.snapshot
@@ -1,0 +1,84 @@
+(*codegen.File)(// Copyright 2025 Outreach Corporation. All Rights Reserved.
+
+// Description: This file is the entrypoint for the cmd1 CLI
+// command for testing.
+// Managed: true
+
+package main
+
+import (
+	"context"
+
+	oapp "github.com/getoutreach/gobox/pkg/app"
+	"github.com/sirupsen/logrus"
+	gcli "github.com/getoutreach/gobox/pkg/cli"
+	"github.com/urfave/cli/v2"
+	"github.com/getoutreach/gobox/pkg/cfg"
+
+	// Place any extra imports for your startup code here
+	// <<Stencil::Block(imports)>>
+
+	// <</Stencil::Block>>
+)
+
+// HoneycombTracingKey gets set by the Makefile at compile-time which is pulled
+// down by devconfig.sh.
+var HoneycombTracingKey = "NOTSET" //nolint:gochecknoglobals // Why: We can't compile in things as a const.
+
+// TeleforkAPIKey gets set by the Makefile at compile-time which is pulled
+// down by devconfig.sh.
+var TeleforkAPIKey = "NOTSET" //nolint:gochecknoglobals // Why: We can't compile in things as a const.
+
+// <<Stencil::Block(honeycombDataset)>>
+
+// HoneycombDataset is a constant denoting the dataset that traces should be stored
+// in in honeycomb.
+const HoneycombDataset = ""
+// <</Stencil::Block>>
+
+// <<Stencil::Block(global)>>
+
+// <</Stencil::Block>>
+
+// main is the entrypoint for the cmd1 CLI.
+func main() {
+	ctx, cancel := context.WithCancel(context.Background())
+	log := logrus.New()
+
+	// <<Stencil::Block(init)>>
+
+	// <</Stencil::Block>>
+
+	app := cli.App{
+		Version: oapp.Version,
+		Name: "cmd1",
+		// <<Stencil::Block(app)>>
+
+		// <</Stencil::Block>>
+	}
+	app.Flags = []cli.Flag{
+		// <<Stencil::Block(flags)>>
+
+		// <</Stencil::Block>>
+	}
+	app.Commands = []*cli.Command{
+		// <<Stencil::Block(commands)>>
+
+		// <</Stencil::Block>>
+	}
+
+	// <<Stencil::Block(postApp)>>
+
+	// <</Stencil::Block>>
+
+	// Insert global flags, tracing, updating and start the application.
+	gcli.Run(ctx, cancel, &app, &gcli.Config{
+		Logger:    log,
+		Telemetry: gcli.TelemetryConfig{
+			Otel: gcli.TelemetryOtelConfig{
+				Dataset:         HoneycombDataset,
+				HoneycombAPIKey: cfg.SecretData(HoneycombTracingKey),
+			},
+		},
+	})
+})

--- a/templates/.snapshots/TestUrfaveCLIV3-cmd-main_cli.go.tpl-cmd-cmd1-cmd1.go.snapshot
+++ b/templates/.snapshots/TestUrfaveCLIV3-cmd-main_cli.go.tpl-cmd-cmd1-cmd1.go.snapshot
@@ -1,0 +1,84 @@
+(*codegen.File)(// Copyright 2025 Outreach Corporation. All Rights Reserved.
+
+// Description: This file is the entrypoint for the cmd1 CLI
+// command for testing.
+// Managed: true
+
+package main
+
+import (
+	"context"
+
+	oapp "github.com/getoutreach/gobox/pkg/app"
+	"github.com/sirupsen/logrus"
+	gcli "github.com/getoutreach/gobox/pkg/cli"
+	"github.com/urfave/cli/v3"
+	"github.com/getoutreach/gobox/pkg/cfg"
+
+	// Place any extra imports for your startup code here
+	// <<Stencil::Block(imports)>>
+
+	// <</Stencil::Block>>
+)
+
+// HoneycombTracingKey gets set by the Makefile at compile-time which is pulled
+// down by devconfig.sh.
+var HoneycombTracingKey = "NOTSET" //nolint:gochecknoglobals // Why: We can't compile in things as a const.
+
+// TeleforkAPIKey gets set by the Makefile at compile-time which is pulled
+// down by devconfig.sh.
+var TeleforkAPIKey = "NOTSET" //nolint:gochecknoglobals // Why: We can't compile in things as a const.
+
+// <<Stencil::Block(honeycombDataset)>>
+
+// HoneycombDataset is a constant denoting the dataset that traces should be stored
+// in in honeycomb.
+const HoneycombDataset = ""
+// <</Stencil::Block>>
+
+// <<Stencil::Block(global)>>
+
+// <</Stencil::Block>>
+
+// main is the entrypoint for the cmd1 CLI.
+func main() {
+	ctx, cancel := context.WithCancel(context.Background())
+	log := logrus.New()
+
+	// <<Stencil::Block(init)>>
+
+	// <</Stencil::Block>>
+
+	app := cli.Command{
+		Version: oapp.Version,
+		Name: "cmd1",
+		// <<Stencil::Block(app)>>
+
+		// <</Stencil::Block>>
+	}
+	app.Flags = []cli.Flag{
+		// <<Stencil::Block(flags)>>
+
+		// <</Stencil::Block>>
+	}
+	app.Commands = []*cli.Command{
+		// <<Stencil::Block(commands)>>
+
+		// <</Stencil::Block>>
+	}
+
+	// <<Stencil::Block(postApp)>>
+
+	// <</Stencil::Block>>
+
+	// Insert global flags, tracing, updating and start the application.
+	gcli.RunV3(ctx, cancel, &app, &gcli.Config{
+		Logger:    log,
+		Telemetry: gcli.TelemetryConfig{
+			Otel: gcli.TelemetryOtelConfig{
+				Dataset:         HoneycombDataset,
+				HoneycombAPIKey: cfg.SecretData(HoneycombTracingKey),
+			},
+		},
+	})
+})

--- a/templates/.snapshots/TestUrfaveCLIV3-cmd-main_cli.go.tpl-cmd-cmd1-cmd1.go.snapshot
+++ b/templates/.snapshots/TestUrfaveCLIV3-cmd-main_cli.go.tpl-cmd-cmd1-cmd1.go.snapshot
@@ -52,6 +52,7 @@ func main() {
 	app := cli.Command{
 		Version: oapp.Version,
 		Name: "cmd1",
+		EnableShellCompletion: true,
 		// <<Stencil::Block(app)>>
 
 		// <</Stencil::Block>>

--- a/templates/_helpers.tpl
+++ b/templates/_helpers.tpl
@@ -143,8 +143,13 @@ go:
 {{- end }}
 
 {{- if stencil.Arg "commands" }}
+{{- if eq (stencil.Arg "versions.urfave-cli") "v3" }}
+- name: github.com/urfave/cli/v3
+  version: v3.3.3
+{{- else }}
 - name: github.com/urfave/cli/v2
   version: v2.16.3
+{{- end }}
 {{- end }}
 
 {{- if stencil.Arg "kubernetes.groups" }}

--- a/templates/_helpers.tpl
+++ b/templates/_helpers.tpl
@@ -122,7 +122,7 @@ secrets:
 {{- define "dependencies" }}
 go:
 - name: github.com/getoutreach/gobox
-  version: v1.104.0
+  version: v1.107.0
 - name: github.com/getoutreach/stencil-golang/pkg
   # To obtain, set `github.com/getoutreach/stencil-golang/pkg` to 'main'
   # in a go.mod and run `go mod tidy`.

--- a/templates/cmd/main_cli.go.tpl
+++ b/templates/cmd/main_cli.go.tpl
@@ -87,6 +87,9 @@ func main() {
 	app := cli.{{ $urfaveCommand }}{
 		Version: oapp.Version,
 		Name: "{{ .cmdName }}",
+{{- if eq (stencil.Arg "versions.urfave-cli") "v3" }}
+		EnableShellCompletion: true,
+{{- end }}
 		// <<Stencil::Block(app)>>
 {{ file.Block "app" }}
 		// <</Stencil::Block>>

--- a/templates/cmd/main_cli.go.tpl
+++ b/templates/cmd/main_cli.go.tpl
@@ -26,13 +26,22 @@ func main() {
 
 package main
 
+{{- $urfaveCommand := "App" }}
+{{- $urfaveImport := (cat "github.com/urfave/cli/" (stencil.Arg "versions.urfave-cli")) | nospace }}
+{{- $gcliRun := "Run" }}
+{{- if eq (stencil.Arg "versions.urfave-cli") "v3" }}
+{{- $urfaveCommand = "Command" }}
+{{- $urfaveImport = (cat "github.com/urfave/cli/v3") | nospace }}
+{{- $gcliRun = "RunV3" }}
+{{- end }}
+
 import (
 	"context"
 
 	oapp "github.com/getoutreach/gobox/pkg/app"
 	"github.com/sirupsen/logrus"
 	gcli "github.com/getoutreach/gobox/pkg/cli"
-	"github.com/urfave/cli/v2"
+	{{ $urfaveImport | quote }}
 	"github.com/getoutreach/gobox/pkg/cfg"
 
 	// Place any extra imports for your startup code here
@@ -75,7 +84,7 @@ func main() {
 {{ file.Block "init" }}
 	// <</Stencil::Block>>
 
-	app := cli.App{
+	app := cli.{{ $urfaveCommand }}{
 		Version: oapp.Version,
 		Name: "{{ .cmdName }}",
 		// <<Stencil::Block(app)>>
@@ -98,7 +107,7 @@ func main() {
 	// <</Stencil::Block>>
 
 	// Insert global flags, tracing, updating and start the application.
-	gcli.Run(ctx, cancel, &app, &gcli.Config{
+	gcli.{{ $gcliRun }}(ctx, cancel, &app, &gcli.Config{
 		Logger:    log,
 		Telemetry: gcli.TelemetryConfig{
 			{{- if .opts.delibird }}

--- a/templates/main_test.go
+++ b/templates/main_test.go
@@ -233,7 +233,7 @@ func TestGRPCServerRPC(t *testing.T) {
 			"grpc",
 		},
 	})
-	st.Run(true)
+	st.Run(stenciltest.RegenerateSnapshots())
 }
 
 func TestGoreleaserYml(t *testing.T) {
@@ -247,7 +247,7 @@ func TestGoreleaserYml(t *testing.T) {
 			"cmd4_sub1",
 		},
 	})
-	st.Run(true)
+	st.Run(stenciltest.RegenerateSnapshots())
 }
 
 func TestRenderGolangcilintYaml(t *testing.T) {
@@ -255,5 +255,31 @@ func TestRenderGolangcilintYaml(t *testing.T) {
 	st.Args(map[string]interface{}{
 		"lintroller": "platinum",
 	})
-	st.Run(true)
+	st.Run(stenciltest.RegenerateSnapshots())
+}
+
+func TestUrfaveCLIV2(t *testing.T) {
+	st := stenciltest.New(t, "cmd/main_cli.go.tpl", libraryTmpls...)
+	st.Args(map[string]any{
+		"commands": []any{
+			"cmd1",
+		},
+		"versions": map[string]any{
+			"urfave-cli": "v2",
+		},
+	})
+	st.Run(stenciltest.RegenerateSnapshots())
+}
+
+func TestUrfaveCLIV3(t *testing.T) {
+	st := stenciltest.New(t, "cmd/main_cli.go.tpl", libraryTmpls...)
+	st.Args(map[string]any{
+		"commands": []any{
+			"cmd1",
+		},
+		"versions": map[string]any{
+			"urfave-cli": "v3",
+		},
+	})
+	st.Run(stenciltest.RegenerateSnapshots())
 }


### PR DESCRIPTION
## What this PR does / why we need it

Adds `versions.urfave-cli` to the service manifest to allow services to use `urfave/cli/v3` instead of `v2`. Defaults to `v2` for backwards compatibility.

## Jira ID

[DT-4762]

## Notes for your reviewers

### TODO

- [x] Merge/release https://github.com/getoutreach/gobox/pull/668
- [x] Update `gobox` version in `templates/_helpers.tpl`


[DT-4762]: https://outreach-io.atlassian.net/browse/DT-4762?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ