### PR TITLE
fix(gobox): bump required version to 1.107.1

### DIFF
--- a/templates/.snapshots/TestBasicGoMod-go.mod.tpl-go.mod.snapshot
+++ b/templates/.snapshots/TestBasicGoMod-go.mod.tpl-go.mod.snapshot
@@ -5,6 +5,6 @@ go 1.23.0
 toolchain go1.23.4
 
 require (
-	github.com/getoutreach/gobox v1.107.0
+	github.com/getoutreach/gobox v1.107.1
 	github.com/getoutreach/stencil-golang/pkg v0.0.0-20250109193043-fa44ea640e7e
 ))

--- a/templates/.snapshots/TestGoModStanzaVersion-go.mod.tpl-go.mod.snapshot
+++ b/templates/.snapshots/TestGoModStanzaVersion-go.mod.tpl-go.mod.snapshot
@@ -5,6 +5,6 @@ go 1.19
 toolchain go1.23.4
 
 require (
-	github.com/getoutreach/gobox v1.107.0
+	github.com/getoutreach/gobox v1.107.1
 	github.com/getoutreach/stencil-golang/pkg v0.0.0-20250109193043-fa44ea640e7e
 ))

--- a/templates/.snapshots/TestMergeGoMod-go.mod.tpl-go.mod.snapshot
+++ b/templates/.snapshots/TestMergeGoMod-go.mod.tpl-go.mod.snapshot
@@ -8,7 +8,7 @@ toolchain go1.23.4
 
 require (
 	github.com/blang/semver/v4 v4.0.0
-	github.com/getoutreach/gobox v1.107.0
+	github.com/getoutreach/gobox v1.107.1
 	github.com/getoutreach/stencil v1.28.0-rc.2
 	github.com/pkg/errors v0.9.1
 	github.com/sirupsen/logrus v1.9.0

--- a/templates/_helpers.tpl
+++ b/templates/_helpers.tpl
@@ -122,7 +122,7 @@ secrets:
 {{- define "dependencies" }}
 go:
 - name: github.com/getoutreach/gobox
-  version: v1.107.0
+  version: v1.107.1
 - name: github.com/getoutreach/stencil-golang/pkg
   # To obtain, set `github.com/getoutreach/stencil-golang/pkg` to 'main'
   # in a go.mod and run `go mod tidy`.


### PR DESCRIPTION
## What this PR does / why we need it

Another bump for CLIs.

## Jira ID

[DT-4767]

[DT-4767]: https://outreach-io.atlassian.net/browse/DT-4767?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ