### PR TITLE
chore: bump ruby grpc version to `~> 1.72.0`

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,6 +16,6 @@ Please read the [CONTRIBUTING.md](CONTRIBUTING.md) document for guidelines on de
 
 <!-- <<Stencil::Block(overview)>> -->
 
-See [the docs](./docs/intro.md) for more information
+See [the docs](./docs/README.md) for more information
 
 <!-- <</Stencil::Block>> -->

--- a/templates/api/clients/ruby/Gemfile.lock.tpl
+++ b/templates/api/clients/ruby/Gemfile.lock.tpl
@@ -2,19 +2,19 @@
 PATH
   remote: .
   specs:
-    {{ .Config.Name }}_client (1.63.0)
-      grpc (~> 1.38)
+    {{ .Config.Name }}_client (1.0.0)
+      grpc (~> 1.72)
 
 GEM
   remote: https://rubygems.org/
   specs:
-    google-protobuf (3.19.1)
-    googleapis-common-protos-types (1.3.0)
+    google-protobuf (3.25.5)
+    googleapis-common-protos-types (1.5.0)
       google-protobuf (~> 3.14)
-    grpc (1.42.0)
-      google-protobuf (~> 3.18)
+    grpc (1.72.0)
+      google-protobuf (>= 3.25, < 5.0)
       googleapis-common-protos-types (~> 1.0)
-    rake (13.0.6)
+    rake (13.2.1)
 
 PLATFORMS
   -darwin-20

--- a/templates/api/clients/ruby/client.gemspec.tpl
+++ b/templates/api/clients/ruby/client.gemspec.tpl
@@ -20,7 +20,7 @@ Gem::Specification.new do |spec|
     `git ls-files -z`.split("\x0").reject { |f| f.match(%r{^(test|spec|features)/}) }
   end
   spec.require_paths = ["lib", "lib/{{ .Config.Name }}_client"]
-  spec.add_dependency 'grpc', '~> 1.38'
+  spec.add_dependency 'grpc', '~> 1.72'
   spec.add_development_dependency 'rake'
   ## <<Stencil::Block(extraGemSpec)>>
 {{ file.Block "extraGemSpec" }}


### PR DESCRIPTION
<!--
  !!!! README !!!! Please fill this out.

  Please follow conventional commit naming conventions:

  https://www.conventionalcommits.org/en/v1.0.0/#summary
-->

Please read [CONTRIBUTING.md](CONTRIBUTING.md) for additional information on contributing to this repository!

<!-- A short description of what your PR does and what it solves. -->
## What this PR does / why we need it


<!-- <<Stencil::Block(jiraPrefix)>> -->

## Jira ID

https://outreach-io.atlassian.net/browse/STAR-3504

https://outreach-io.atlassian.net/browse/ES-4927

<!-- <</Stencil::Block>> -->

<!-- Notes that may be helpful for anyone reviewing this PR -->
## Notes for your reviewers

I was able to run `make test` and it passed, but I somehow doubt that it tested any of my changes.

I manually updated the lock file.

<!-- <<Stencil::Block(custom)>> -->

<!-- <</Stencil::Block>> -->
