### PR TITLE
fix(devspace): skipPortForwarding does not prevent default ports to be forwarded

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -18,7 +18,7 @@ This project uses devbase, which exposes the following build tooling: [devbase/d
 
 <!-- <</Stencil::Block>> -->
 
-### Replacing a Remote Version of the a Package with Local Version
+### Replacing a Remote Version of the Package with Local Version
 
 _This is only applicable if this repository exposes a public package_.
 

--- a/templates/.snapshots/TestDevspaceYaml-devspace.yaml.tpl-devspace.yaml.snapshot
+++ b/templates/.snapshots/TestDevspaceYaml-devspace.yaml.tpl-devspace.yaml.snapshot
@@ -337,10 +337,13 @@ profiles:
           - port: ${DLV_PORT}
 
   - name: skipPortForwarding
-    description: Skip port-forwarding for all but the DLV port.
+    description: Skip port-forwarding for all ports.
     activation:
       - vars:
           DEVENV_DEV_SKIP_PORTFORWARDING: "true"
+    patches:
+      - op: remove
+        path: dev.app.ports
 
   - name: e2eBase
     description: Basic configuration override for all e2e test profiles

--- a/templates/devspace.yaml.tpl
+++ b/templates/devspace.yaml.tpl
@@ -361,10 +361,13 @@ profiles:
           - port: ${DLV_PORT}
 
   - name: skipPortForwarding
-    description: Skip port-forwarding for all but the DLV port.
+    description: Skip port-forwarding for all ports.
     activation:
       - vars:
           DEVENV_DEV_SKIP_PORTFORWARDING: "true"
+    patches:
+      - op: remove
+        path: dev.app.ports
 
   - name: e2eBase
     description: Basic configuration override for all e2e test profiles


### PR DESCRIPTION
<!--
  !!!! README !!!! Please fill this out.

  Please follow conventional commit naming conventions:

  https://www.conventionalcommits.org/en/v1.0.0/#summary
-->

`--skip-portforwarding` option in devenv apps lets dlv port to be forwarded, this PR disables port forwarding altogether if the flag is used.
<!-- A short description of what your PR does and what it solves. -->
## What this PR does / why we need it


<!-- <<Stencil::Block(jiraPrefix)>> -->

## Jira ID

[DT-4805]

<!-- <</Stencil::Block>> -->

<!-- Notes that may be helpful for anyone reviewing this PR -->
## Notes for your reviewers

<!-- <<Stencil::Block(custom)>> -->

<!-- <</Stencil::Block>> -->


[DT-4805]: https://outreach-io.atlassian.net/browse/DT-4805?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ