### PR TITLE
fix(dependabot): add Go ignore block

### DIFF
--- a/templates/.github/dependabot.yml.tpl
+++ b/templates/.github/dependabot.yml.tpl
@@ -15,6 +15,8 @@ updates:
       - dependency-name: {{ $d.name }}
 {{- end }}
 {{- end }}
+      ## <<Stencil::Block(dependabotGoIgnore)>>
+      ## <</Stencil::Block>>
 
   # Ignore semantic-release, this code is only executed in CI.
   - package-ecosystem: "npm"

--- a/templates/.snapshots/TestRenderDependabot-.github-dependabot.yml.tpl-.github-dependabot.yml.snapshot
+++ b/templates/.snapshots/TestRenderDependabot-.github-dependabot.yml.tpl-.github-dependabot.yml.snapshot
@@ -13,6 +13,8 @@ updates:
       - dependency-name: google.golang.org/grpc
       - dependency-name: github.com/getoutreach/orgservice
       - dependency-name: github.com/getoutreach/services
+      ## <<Stencil::Block(dependabotGoIgnore)>>
+      ## <</Stencil::Block>>
 
   # Ignore semantic-release, this code is only executed in CI.
   - package-ecosystem: "npm"


### PR DESCRIPTION
## What this PR does / why we need it

The use case for this is when we want to manually upgrade a block of Go dependencies.