### PR TITLE
fix(node): pin `@types/node` version

### DIFF
--- a/templates/.snapshots/TestRenderDependabot-.github-dependabot.yml.tpl-.github-dependabot.yml.snapshot
+++ b/templates/.snapshots/TestRenderDependabot-.github-dependabot.yml.tpl-.github-dependabot.yml.snapshot
@@ -40,6 +40,7 @@ updates:
       - dependency-name: "winston"
       - dependency-name: "@getoutreach/eslint-config"
       - dependency-name: "@types/jest"
+      - dependency-name: "@types/node"
       - dependency-name: "@typescript-eslint/eslint-plugin"
       - dependency-name: "@typescript-eslint/parser"
       - dependency-name: "eslint"

--- a/templates/_helpers.tpl
+++ b/templates/_helpers.tpl
@@ -198,6 +198,8 @@ nodejs:
     version: ^2.0.0
   - name: "@types/jest"
     version: ^26.0.15
+  - name: "@types/node"
+    version: ^22.18.3
   - name: "@typescript-eslint/eslint-plugin"
     version: ^7.8.0
   - name: "@typescript-eslint/parser"


### PR DESCRIPTION
## What this PR does / why we need it

A newer version of `@types/node` does not work with the pinned version of TypeScript that we use for the Node.js gRPC client.

## Jira ID

[DT-4835]

[DT-4835]: https://outreach-io.atlassian.net/browse/DT-4835?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ