### PR TITLE
fix(devspace): use mise version task instead of make target

### DIFF
--- a/templates/.snapshots/TestDevspaceYaml-devspace.yaml.tpl-devspace.yaml.snapshot
+++ b/templates/.snapshots/TestDevspaceYaml-devspace.yaml.tpl-devspace.yaml.snapshot
@@ -81,7 +81,7 @@ vars:
   GH_TOKEN: $([[ "$GH_TOKEN" == "null" ]] && unset GH_TOKEN; gh auth token)
   NPM_TOKEN: $(grep -E "registry.npmjs.org(.+)_authToken=(.+)" $HOME/.npmrc | sed 's/.*=//g')
   APP_VERSION: $(make version)
-  BOX_REPOSITORY_URL: $(yq -r '.storageURL' "$HOME/.outreach/.config/box/box.yaml")
+  BOX_REPOSITORY_URL: $(gojq --yaml-input --raw-output '.storageURL' "$HOME/.outreach/.config/box/box.yaml")
 
 
   DLV_PORT:

--- a/templates/.snapshots/TestDevspaceYaml-devspace.yaml.tpl-devspace.yaml.snapshot
+++ b/templates/.snapshots/TestDevspaceYaml-devspace.yaml.tpl-devspace.yaml.snapshot
@@ -80,7 +80,7 @@ vars:
 
   GH_TOKEN: $([[ "$GH_TOKEN" == "null" ]] && unset GH_TOKEN; gh auth token)
   NPM_TOKEN: $(grep -E "registry.npmjs.org(.+)_authToken=(.+)" $HOME/.npmrc | sed 's/.*=//g')
-  APP_VERSION: $(make version)
+  APP_VERSION: $(mise run --quiet version)
   BOX_REPOSITORY_URL: $(gojq --yaml-input --raw-output '.storageURL' "$HOME/.outreach/.config/box/box.yaml")
 
 

--- a/templates/devspace.yaml.tpl
+++ b/templates/devspace.yaml.tpl
@@ -81,7 +81,7 @@ vars:
 
   GH_TOKEN: $([[ "$GH_TOKEN" == "null" ]] && unset GH_TOKEN; gh auth token)
   NPM_TOKEN: $(grep -E "registry.npmjs.org(.+)_authToken=(.+)" $HOME/.npmrc | sed 's/.*=//g')
-  APP_VERSION: $(make version)
+  APP_VERSION: $(mise run --quiet version)
   BOX_REPOSITORY_URL: $(gojq --yaml-input --raw-output '.storageURL' "$HOME/.outreach/.config/box/box.yaml")
 
 

--- a/templates/devspace.yaml.tpl
+++ b/templates/devspace.yaml.tpl
@@ -82,7 +82,7 @@ vars:
   GH_TOKEN: $([[ "$GH_TOKEN" == "null" ]] && unset GH_TOKEN; gh auth token)
   NPM_TOKEN: $(grep -E "registry.npmjs.org(.+)_authToken=(.+)" $HOME/.npmrc | sed 's/.*=//g')
   APP_VERSION: $(make version)
-  BOX_REPOSITORY_URL: $(yq -r '.storageURL' "$HOME/.outreach/.config/box/box.yaml")
+  BOX_REPOSITORY_URL: $(gojq --yaml-input --raw-output '.storageURL' "$HOME/.outreach/.config/box/box.yaml")
 
 
   DLV_PORT:


### PR DESCRIPTION
## What this PR does / why we need it

This should make devspace initialization a little faster since it doesn't have to compile `Magefile.go`.

## Jira ID

[DT-4631]

## Notes for reviewers

### TODO

- [x] Merge #619 
- [x] Merge `main` into this PR

[DT-4631]: https://outreach-io.atlassian.net/browse/DT-4631?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ