### PR TITLE
fix(rpc): rename errors variable to errs to resolve package shadowing

### DIFF
--- a/templates/api/rpc/client.go.tpl
+++ b/templates/api/rpc/client.go.tpl
@@ -87,14 +87,14 @@ type client struct {
 
 // Close is necessary to avoid potential resource leaks
 func (c client) Close(ctx context.Context) error {
-	errors := make([]error, 0)
+	errs := make([]error, 0)
 	for _, fn := range c.closers {
 		if err := fn(ctx); err != nil && !errors.Is(err, context.Canceled) {
-			errors = append(errors, err)
+			errs = append(errs, err)
 		}
 	}
-	if len(errors) != 0 {
-		return fmt.Errorf("failed to close client: %v", errors)
+	if len(errs) != 0 {
+		return fmt.Errorf("failed to close client: %v", errs)
 	}
 
 	return nil


### PR DESCRIPTION
## What this PR does / why we need it

The `errors` slice variable introduced in the `Close` function was shadowing the imported `"errors"` standard library package. This caused `errors.Is` to be called on the slice variable rather than the package, which would result in a compilation error. Renaming the variable to `errs` resolves the shadowing.

## Jira ID

[DT-5253](https://outreach-io.atlassian.net/browse/DT-5253)

## Notes for your reviewers

Only the local variable name changes — behaviour is identical. The `errors.Is` call now correctly refers to the `errors` package as intended.

[DT-5253]: https://outreach-io.atlassian.net/browse/DT-5253?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ