### PR TITLE
fix(devspace): ensure that devbase tasks exist before running the version task

### DIFF
--- a/templates/.snapshots/TestDevspaceYaml-devspace.yaml.tpl-devspace.yaml.snapshot
+++ b/templates/.snapshots/TestDevspaceYaml-devspace.yaml.tpl-devspace.yaml.snapshot
@@ -80,7 +80,7 @@ vars:
 
   GH_TOKEN: $([[ "$GH_TOKEN" == "null" ]] && unset GH_TOKEN; gh auth token)
   NPM_TOKEN: $(grep -E "registry.npmjs.org(.+)_authToken=(.+)" $HOME/.npmrc | sed 's/.*=//g')
-  APP_VERSION: $(mise run --quiet version)
+  APP_VERSION: $(./scripts/devbase.sh && mise run --quiet version)
   BOX_REPOSITORY_URL: $(gojq --yaml-input --raw-output '.storageURL' "$HOME/.outreach/.config/box/box.yaml")
 
 

--- a/templates/devspace.yaml.tpl
+++ b/templates/devspace.yaml.tpl
@@ -81,7 +81,7 @@ vars:
 
   GH_TOKEN: $([[ "$GH_TOKEN" == "null" ]] && unset GH_TOKEN; gh auth token)
   NPM_TOKEN: $(grep -E "registry.npmjs.org(.+)_authToken=(.+)" $HOME/.npmrc | sed 's/.*=//g')
-  APP_VERSION: $(mise run --quiet version)
+  APP_VERSION: $(./scripts/devbase.sh && mise run --quiet version)
   BOX_REPOSITORY_URL: $(gojq --yaml-input --raw-output '.storageURL' "$HOME/.outreach/.config/box/box.yaml")
 
 


### PR DESCRIPTION
## What this PR does / why we need it

Unclear why more people haven't reported this bug. Ran into this in a devenv E2E test.

Running `./scripts/devbase.sh` is idempotent so running this on every devspace initialization is fine.

## Jira ID

[DT-5261]

[DT-5261]: https://outreach-io.atlassian.net/browse/DT-5261?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ