### PR TITLE
feat(dependencies): bump the version of services in go.mod

### DIFF
--- a/templates/_helpers.tpl
+++ b/templates/_helpers.tpl
@@ -143,7 +143,7 @@ go:
   version: v1.148.6
   # Used for grpcx
 - name: github.com/getoutreach/services
-  version: v1.218.0
+  version: v1.246.2
 {{- end }}
 {{- if has "http" (stencil.Arg "serviceActivities") }}
 - name: github.com/getoutreach/httpx


### PR DESCRIPTION
On the tin.
This update instructions slightly easier.