### PR TITLE
fix: bump nodejs default client version

### DIFF
--- a/manifest.yaml
+++ b/manifest.yaml
@@ -178,7 +178,7 @@ arguments:
         - number
   versions.grpcClients.nodejs:
     description: Nodejs version to use for gRPC clients
-    default: "20.16.0"
+    default: "22.22.0"
     schema:
       type:
         - string


### PR DESCRIPTION
<!--
  !!!! README !!!! Please fill this out.

  Please follow conventional commit naming conventions:

  https://www.conventionalcommits.org/en/v1.0.0/#summary
-->

Please read [CONTRIBUTING.md](CONTRIBUTING.md) for additional information on contributing to this repository!

<!-- A short description of what your PR does and what it solves. -->
## What this PR does / why we need it


<!-- <<Stencil::Block(jiraPrefix)>> -->

## Jira ID

[XX-XX]

<!-- <</Stencil::Block>> -->

<!-- Notes that may be helpful for anyone reviewing this PR -->
## Notes for your reviewers
Currently installed version of NodeJS on repo level conflicts with the one in generated node client. This is an attempt to get it to latest
<!-- <<Stencil::Block(custom)>> -->

<!-- <</Stencil::Block>> -->




<!-- Rovo Dev code review status -->
---
Rovo Dev code review: <strong>Rovo Dev has reviewed this pull request</strong>
Any suggestions or improvements have been posted as pull request comments.
<!-- /Rovo Dev code review status -->

