### PR TITLE
fix(grpc): upgrade Node.js version to 20.20.2

### DIFF
--- a/manifest.yaml
+++ b/manifest.yaml
@@ -178,7 +178,7 @@ arguments:
         - number
   versions.grpcClients.nodejs:
     description: Nodejs version to use for gRPC clients
-    default: "20.16.0"
+    default: "20.20.2"
     schema:
       type:
         - string


### PR DESCRIPTION
## What this PR does / why we need it

Needed so that we can upgrade the GraphQL server to the same Node.js version.

## Jira ID

[DT-5289]

[DT-5289]: https://outreach-io.atlassian.net/browse/DT-5289?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ



<!-- Rovo Dev code review status -->
---
Rovo Dev code review: <strong>Rovo Dev has reviewed this pull request</strong>
Any suggestions or improvements have been posted as pull request comments.
<!-- /Rovo Dev code review status -->

