### PR TITLE
fix: failing oxlint and test_node_client

### DIFF
--- a/manifest.yaml
+++ b/manifest.yaml
@@ -178,7 +178,7 @@ arguments:
         - number
   versions.grpcClients.nodejs:
     description: Nodejs version to use for gRPC clients
-    default: "20.16.0"
+    default: "22.22.0"
     schema:
       type:
         - string


### PR DESCRIPTION
<!--
  !!!! README !!!! Please fill this out.

  Please follow conventional commit naming conventions:

  https://www.conventionalcommits.org/en/v1.0.0/#summary
-->

Please read [CONTRIBUTING.md](CONTRIBUTING.md) for additional information on contributing to this repository!

<!-- A short description of what your PR does and what it solves. -->
## What this PR does / why we need it

Recently oxlint was introduced but it requires new nodejs version, the root-level `.tool-versions` is fine but there is a special `.tool-versions` in `api/clients/node/` which is much older. No idea why we need to have a different version here, but this patch helps. The only occurance of that version is really in https://github.com/getoutreach/stencil-golang/blob/main/templates/api/clients/node/.tool-versions.tpl only.

Without it `stencil` log contains an error

```
error oxlint@1.60.0: The engine "node" is incompatible with this module. Expected version "^20.19.0 || >=22.12.0". Got "20.16.0"
error Found incompatible module.
```

and also the `test_node_client` step fails, normally it's not required so people don't care but we have it required in some services...

<!-- <<Stencil::Block(jiraPrefix)>> -->

## Jira ID

[XX-XX]

<!-- <</Stencil::Block>> -->

<!-- Notes that may be helpful for anyone reviewing this PR -->
## Notes for your reviewers

<!-- <<Stencil::Block(custom)>> -->

<!-- <</Stencil::Block>> -->

<!-- Rovo Dev code review status -->
---
Rovo Dev code review: <strong>Rovo Dev is reviewing this pull request…</strong>
Refresh the page in a few minutes to see the results.
<!-- /Rovo Dev code review status -->

