### PR TITLE
feat: Added fflags package initialization for go services.

### DIFF
--- a/docs/arguments.md
+++ b/docs/arguments.md
@@ -146,3 +146,14 @@ Evaluation time frame for Datadog to evaluate the ArgoCD Application Health moni
 **Default**: `last_15m`
 
 Evaluation time frame for Datadog to evaluate the ArgoCD Sync Status monitor.
+
+## `disableDefaultLaunchDarklyClient`
+
+**Type**: `bool`
+**Default**: `false`
+
+When false (the default), stencil will:
+- Add fflags.New() to the runners collection in main.go
+- Enforce a minimum version of the fflags package (v1.20.0+) in go.mod
+  Set this to true if your service uses a custom LaunchDarkly client instead of the default fflags.
+  `disableDefaultLaunchDarklyClient: true`

--- a/docs/arguments.md
+++ b/docs/arguments.md
@@ -155,5 +155,8 @@ Evaluation time frame for Datadog to evaluate the ArgoCD Sync Status monitor.
 When false (the default), stencil will:
 - Add fflags.New() to the runners collection in main.go
 - Enforce a minimum version of the fflags package (v1.20.0+) in go.mod
-  Set this to true if your service uses a custom LaunchDarkly client instead of the default fflags.
-  `disableDefaultLaunchDarklyClient: true`
+
+Set this to true if your service uses a custom LaunchDarkly client instead of the default fflags.  
+```yaml
+disableDefaultLaunchDarklyClient: true
+```

--- a/manifest.yaml
+++ b/manifest.yaml
@@ -272,4 +272,9 @@ arguments:
       type: array
       items:
         type: string
+  disableDefaultLaunchDarklyClient:
+    description: Disable default LaunchDarkly feature flags (fflags) client integration.
+    default: false
+    schema:
+      type: boolean
 ## <</Stencil::Block>>

--- a/templates/.snapshots/TestGoModWithDisableLaunchDarklyClient-go.mod.tpl-go.mod.snapshot
+++ b/templates/.snapshots/TestGoModWithDisableLaunchDarklyClient-go.mod.tpl-go.mod.snapshot
@@ -1,0 +1,10 @@
+(*codegen.File)(module github.com/getoutreach/testing
+
+go 1.25.0
+
+toolchain go1.25.7
+
+require (
+	github.com/getoutreach/gobox v1.111.4
+	github.com/getoutreach/stencil-golang/pkg v0.0.0-20250109193043-fa44ea640e7e
+))

--- a/templates/.snapshots/TestGoModWithService-go.mod.tpl-go.mod.snapshot
+++ b/templates/.snapshots/TestGoModWithService-go.mod.tpl-go.mod.snapshot
@@ -1,0 +1,11 @@
+(*codegen.File)(module github.com/getoutreach/testing
+
+go 1.25.0
+
+toolchain go1.25.7
+
+require (
+	github.com/getoutreach/gobox v1.111.4
+	github.com/getoutreach/stencil-golang/pkg v0.0.0-20250109193043-fa44ea640e7e
+	github.com/getoutreach/fflags v1.20.0
+))

--- a/templates/.snapshots/TestOSSCopyright-cmd-main.go.tpl-cmd-testing-main.go.snapshot
+++ b/templates/.snapshots/TestOSSCopyright-cmd-main.go.tpl-cmd-testing-main.go.snapshot
@@ -10,7 +10,7 @@ package main
 import (
 	"context"
 	"os"
-
+	"github.com/getoutreach/fflags/pkg/fflags"
 	"github.com/getoutreach/gobox/pkg/app"
 	"github.com/getoutreach/gobox/pkg/async"
 	"github.com/getoutreach/gobox/pkg/env"
@@ -86,6 +86,7 @@ func main() { //nolint: funlen // Why: We can't dwindle this down anymore withou
 		shutdown.New(),
 		gomaxprocs.New(),
 		automemlimit.New(),
+		fflags.New(),
 		testing.NewHTTPService(cfg, &deps.privateHTTP),
 
 		// Place any additional ServiceActivities that your service has built here to have them handled automatically

--- a/templates/.snapshots/TestRenderDependabot-.github-dependabot.yml.tpl-.github-dependabot.yml.snapshot
+++ b/templates/.snapshots/TestRenderDependabot-.github-dependabot.yml.tpl-.github-dependabot.yml.snapshot
@@ -13,6 +13,7 @@ updates:
     # stencil-golang managed dependencies
     ignore:
       - dependency-name: github.com/getoutreach/gobox
+      - dependency-name: github.com/getoutreach/fflags
       - dependency-name: github.com/getoutreach/stencil-golang/pkg
       - dependency-name: google.golang.org/grpc
       - dependency-name: github.com/getoutreach/orgservice

--- a/templates/.snapshots/TestRenderDependabot-.github-dependabot.yml.tpl-.github-dependabot.yml.snapshot
+++ b/templates/.snapshots/TestRenderDependabot-.github-dependabot.yml.tpl-.github-dependabot.yml.snapshot
@@ -13,8 +13,8 @@ updates:
     # stencil-golang managed dependencies
     ignore:
       - dependency-name: github.com/getoutreach/gobox
-      - dependency-name: github.com/getoutreach/fflags
       - dependency-name: github.com/getoutreach/stencil-golang/pkg
+      - dependency-name: github.com/getoutreach/fflags
       - dependency-name: google.golang.org/grpc
       - dependency-name: github.com/getoutreach/orgservice
       - dependency-name: github.com/getoutreach/services

--- a/templates/_helpers.tpl
+++ b/templates/_helpers.tpl
@@ -131,6 +131,10 @@ secrets:
 go:
 - name: github.com/getoutreach/gobox
   version: v1.111.4
+{{- if and (stencil.Arg "service") (not (stencil.Arg "disableDefaultLaunchDarklyClient")) }}
+- name: github.com/getoutreach/fflags
+  version: v1.20.0
+{{- end }}
 - name: github.com/getoutreach/stencil-golang/pkg
   # To obtain, set `github.com/getoutreach/stencil-golang/pkg` to 'main'
   # in a go.mod and run `go mod tidy`.

--- a/templates/_helpers.tpl
+++ b/templates/_helpers.tpl
@@ -131,14 +131,15 @@ secrets:
 go:
 - name: github.com/getoutreach/gobox
   version: v1.111.4
-{{- if and (stencil.Arg "service") (not (stencil.Arg "disableDefaultLaunchDarklyClient")) }}
-- name: github.com/getoutreach/fflags
-  version: v1.20.0
-{{- end }}
 - name: github.com/getoutreach/stencil-golang/pkg
   # To obtain, set `github.com/getoutreach/stencil-golang/pkg` to 'main'
   # in a go.mod and run `go mod tidy`.
   version: v0.0.0-20250109193043-fa44ea640e7e
+
+{{- if and (stencil.Arg "service") (not (stencil.Arg "disableDefaultLaunchDarklyClient")) }}
+- name: github.com/getoutreach/fflags
+  version: v1.20.0
+{{- end }}
 
 {{- if has "grpc" (stencil.Arg "serviceActivities") }}
 - name: google.golang.org/grpc

--- a/templates/cmd/main.go.tpl
+++ b/templates/cmd/main.go.tpl
@@ -13,6 +13,9 @@ import (
 	"context"
 	"os"
 
+{{- if not (stencil.Arg "disableDefaultLaunchDarklyClient") }}
+	"github.com/getoutreach/fflags/pkg/fflags"
+{{- end }}
 	"github.com/getoutreach/gobox/pkg/app"
 	"github.com/getoutreach/gobox/pkg/async"
 	"github.com/getoutreach/gobox/pkg/env"
@@ -128,6 +131,9 @@ func main() { //nolint: funlen // Why: We can't dwindle this down anymore withou
 		shutdown.New(),
 		gomaxprocs.New(),
 		automemlimit.New(),
+		{{- if not (stencil.Arg "disableDefaultLaunchDarklyClient") }}
+		fflags.New(),
+		{{- end }}
 		{{ $pkgName }}.NewHTTPService(cfg, &deps.privateHTTP),
 		{{- if has "http" (stencil.Arg "serviceActivities") }}
 		{{ $pkgName }}.NewPublicHTTPService(cfg, &deps.publicHTTP),

--- a/templates/main_test.go
+++ b/templates/main_test.go
@@ -191,6 +191,37 @@ func TestBasicGoMod(t *testing.T) {
 	st.Run(stenciltest.RegenerateSnapshots())
 }
 
+func TestGoModWithService(t *testing.T) {
+	st := stenciltest.New(t, "go.mod.tpl", libraryTmpls...)
+	st.Args(map[string]interface{}{
+		"service": true,
+	})
+
+	p, err := plugin.NewStencilGolangPlugin(context.Background())
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	st.Ext("github.com/getoutreach/stencil-golang", p)
+	st.Run(stenciltest.RegenerateSnapshots())
+}
+
+func TestGoModWithDisableLaunchDarklyClient(t *testing.T) {
+	st := stenciltest.New(t, "go.mod.tpl", libraryTmpls...)
+	st.Args(map[string]interface{}{
+		"service":                          true,
+		"disableDefaultLaunchDarklyClient": true,
+	})
+
+	p, err := plugin.NewStencilGolangPlugin(context.Background())
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	st.Ext("github.com/getoutreach/stencil-golang", p)
+	st.Run(stenciltest.RegenerateSnapshots())
+}
+
 func TestMergeGoMod(t *testing.T) {
 	st := stenciltest.New(t, "go.mod.tpl", libraryTmpls...)
 


### PR DESCRIPTION
## What this PR does / why we need it

This is a follow-up PR to add fflags package initialization to all go services.
It includes:
- added v1.20.0+ version of fflags package into template for go.mod
- added necessary imports and runners into main.go template
- added stencil argument `disableDefaultLaunchDarklyClient` to opt-out of behavior introduced in this PR.
- added extra go.mod tests to cover usage scenarios
- updated test snapshots

<!-- <<Stencil::Block(jiraPrefix)>> -->

## Jira ID

[DT-4960](https://outreach-io.atlassian.net/browse/DT-4960)

<!-- <</Stencil::Block>> -->

<!-- Notes that may be helpful for anyone reviewing this PR -->
## Notes for your reviewers

This change belongs here because:
- Added initialization of fflags should require zero effort from service teams
- This repo is already aware of launchdarkly as it adds a configmap via app.jsonnet.tpl template.

<!-- <<Stencil::Block(custom)>> -->

<!-- <</Stencil::Block>> -->


[DT-4960]: https://outreach-io.atlassian.net/browse/DT-4960?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ



<!-- Rovo Dev code review status -->
---
Rovo Dev code review: <strong>Rovo Dev has reviewed this pull request</strong>
Any suggestions or improvements have been posted as pull request comments.
<!-- /Rovo Dev code review status -->

