### PR TITLE
fix(nodejs): add yarn resolution for grpc_tools_node_protoc_ts/handlebars

### DIFF
--- a/templates/.snapshots/TestRenderNodeJSPackageHJSON-api-clients-node-package.hjson.tpl-api-clients-node-package.hjson.snapshot
+++ b/templates/.snapshots/TestRenderNodeJSPackageHJSON-api-clients-node-package.hjson.tpl-api-clients-node-package.hjson.snapshot
@@ -1,48 +1,56 @@
-{{- $_ := stencil.ApplyTemplate "skipGrpcClient" "node" -}}
-{
+(*codegen.File)({
   // This file is not automatically turned into package.json
   // In order to do so, run: `make gogenerate` in the root
   // of this repository.
 
-  "name": "@getoutreach/{{ .Config.Name }}-client",
+  "name": "@getoutreach/testing-client",
   "version": "0.0.1",
-  "description": "{{ .Config.Name }} client implementation",
+  "description": "testing client implementation",
   "main": "dist/index.js",
-  "repository": "https://github.com/getoutreach/{{ .Config.Name }}",
+  "repository": "https://github.com/getoutreach/testing",
   "files": [
     // <<Stencil::Block(nodeDistFiles)>>
-{{ file.Block "nodeDistFiles" }}
+
     // <</Stencil::Block>>
     "dist"
   ],
   "license": "UNLICENSED",
   "dependencies": {
     // <<Stencil::Block(nodeDependencies)>>
-{{ file.Block "nodeDependencies" }}
+
     // <</Stencil::Block>>
-  {{- range $d := (stencil.ApplyTemplate "dependencies" | fromYaml).nodejs.dependencies }}
-    "{{ $d.name }}": "{{ $d.version }}",
-  {{- end }}
+    "@grpc/grpc-js": "1.8.22",
+    "@getoutreach/grpc-client": "^2.4.0",
+    "@getoutreach/find": "^1.1.0",
+    "@types/google-protobuf": "^3.15.0",
+    "google-protobuf": "^3.15.0",
+    "ts-enum-util": "^4.0.2",
+    "winston": "^3.13.0",
   },
   "devDependencies": {
     // <<Stencil::Block(nodeDevDependencies)>>
-{{ file.Block "nodeDevDependencies" }}
+
     // <</Stencil::Block>>
-  {{- range $d := (stencil.ApplyTemplate "dependencies" | fromYaml).nodejs.devDependencies }}
-    "{{ $d.name }}": "{{ $d.version }}",
-  {{- end }}
+    "@getoutreach/oxlint-config": "^1.0.0",
+    "@types/jest": "^26.0.15",
+    "@types/node": "^22.18.3",
+    "grpc-tools": "^1.12.4",
+    "grpc_tools_node_protoc_ts": "^5.0.1",
+    "jest": "^26.6.3",
+    "npm-run-all": "^4.1.5",
+    "oxlint": "^1.58.0",
+    "prettier": "^3.0.0",
+    "ts-jest": "^26.4.4",
+    "ts-node": "^9.0.0",
+    "tsconfig-paths": "^3.9.0",
+    "typescript": "^4.9.5",
   },
-{{- $yarnResolutions := (stencil.ApplyTemplate "dependencies" | fromYaml).nodejs.yarnResolutions }}
-{{- if not (empty $yarnResolutions) }}
   "resolutions": {
-  {{- range $resolution := $yarnResolutions }}
-    {{ $resolution.name | quote }}: {{ $resolution.version | quote }}
-  {{- end }}
+    "grpc_tools_node_protoc_ts/handlebars": "^4.7.9"
   },
-{{- end }}
   "scripts": {
     // <<Stencil::Block(nodeScripts)>>
-{{ file.Block "nodeScripts" }}
+
     // <</Stencil::Block>>
     "build": "npm-run-all clean tsc",
     "ci": "npm-run-all pretty lint test-ci",
@@ -66,3 +74,4 @@
     "js"
   ]
 }
+)

--- a/templates/_helpers.tpl
+++ b/templates/_helpers.tpl
@@ -228,4 +228,7 @@ nodejs:
   - name: {{ .name }}
     version: {{ .version }}
 {{- end }}
+  yarnResolutions:
+  - name: grpc_tools_node_protoc_ts/handlebars
+    version: ^4.7.9
 {{- end }}

--- a/templates/main_test.go
+++ b/templates/main_test.go
@@ -350,3 +350,12 @@ func TestUrfaveCLIV3(t *testing.T) {
 	})
 	st.Run(stenciltest.RegenerateSnapshots())
 }
+func TestRenderNodeJSPackageHJSON(t *testing.T) {
+	st := stenciltest.New(t, "api/clients/node/package.hjson.tpl", libraryTmpls...)
+	st.Args(map[string]any{
+		"service":           true,
+		"serviceActivities": []any{"grpc"},
+		"grpcClients":       []any{"node"},
+	})
+	st.Run(stenciltest.RegenerateSnapshots())
+}


### PR DESCRIPTION
## What this PR does / why we need it

Works around a security vulnerability, as the `grpc_tools_node_protoc_ts` package hasn't been updated in years.

## Jira ID

[DT-5326]

## Notes for reviewers

Adds a test snapshot for `api/clients/node/package.hjson.tpl` and also fixes some whitespace (tabs :arrow_right: spaces for consistency).

[DT-5326]: https://outreach-io.atlassian.net/browse/DT-5326?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ



<!-- Rovo Dev code review status -->
---
Rovo Dev code review: <strong>Rovo Dev has reviewed this pull request</strong>
Any suggestions or improvements have been posted as pull request comments.
<!-- /Rovo Dev code review status -->

