### PR TITLE
fix: don't emit .goreleaser.yml if releaseOptions.enabled is false

### DIFF
--- a/manifest.yaml
+++ b/manifest.yaml
@@ -46,6 +46,11 @@ arguments:
       type: boolean
     description: Deprecated, denotes this is an open source repository.
     deprecated: true
+  releaseOptions.enabled:
+    description: (From stencil-base) Whether the repository makes releases.
+    schema:
+      type: boolean
+    default: true
   commands:
     schema:
       type: array

--- a/templates/.goreleaser.yml.tpl
+++ b/templates/.goreleaser.yml.tpl
@@ -1,3 +1,4 @@
+{{- if stencil.Arg "releaseOptions.enabled" }}
 {{- if not (stencil.Arg "commands") }}
 {{ file.Skip "No commands defined" }}
 {{- end -}}
@@ -41,3 +42,6 @@ checksum:
 release:
   # We handle releasing via semantic-release
   disable: true
+{{- else }}
+{{- file.Delete }}
+{{- end }}


### PR DESCRIPTION
## What this PR does / why we need it

This is primarily for the minority of repos which are internal-only, declare CLIs, but are not meant for distribution.

## Notes for your reviewers

Specifically avoids adding a dependency on `stencil-base`, I don't want to deal with a potentially large change at this time.



<!-- Rovo Dev code review status -->
---
Rovo Dev code review: <strong>Rovo Dev has reviewed this pull request</strong>
Any suggestions or improvements have been posted as pull request comments.
<!-- /Rovo Dev code review status -->

