### PR TITLE
fix(manifest): deprecations are strings, not bools

### DIFF
--- a/manifest.yaml
+++ b/manifest.yaml
@@ -45,7 +45,7 @@ arguments:
     schema:
       type: boolean
     description: Deprecated, denotes this is an open source repository.
-    deprecated: true
+    deprecated: "definition migrated to github.com/getoutreach/stencil-base"
   releaseOptions.enabled:
     description: (From stencil-base) Whether the repository makes releases.
     schema:
@@ -138,8 +138,8 @@ arguments:
       type: array
       items:
         type: string
-    description: "List of mixins to also import. Set in override.jsonnet instead"
-    deprecated: true
+    description: "Deprecated, list of mixins to also import. Set in override.jsonnet instead"
+    deprecated: "set mixins in your .override.jsonnet file instead"
   dependencies.optional:
     schema:
       type: array


### PR DESCRIPTION
## What this PR does / why we need it

The `deprecated:` field was never defined, so we're defining it now as:

* empty: not deprecated
* not-empty: deprecated, provides instructions for how to deal with the field's deprecation

## Jira ID

[DT-5388]

[DT-5388]: https://outreach-io.atlassian.net/browse/DT-5388?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ