### PR TITLE
feat(deployments): add prometheus ServiceMonitor (FND-956)

### DIFF
--- a/templates/.snapshots/TestRenderDeploymentJsonnet-deployments-appname-app.jsonnet.tpl-deployments-testing-testing.jsonnet.snapshot
+++ b/templates/.snapshots/TestRenderDeploymentJsonnet-deployments-appname-app.jsonnet.tpl-deployments-testing-testing.jsonnet.snapshot
@@ -65,14 +65,6 @@ local all = {
 		},
 		spec+: { maxUnavailable: '15%' },
 	},
-	// ServiceMonitor tells the Prometheus operator to scrape this service's
-	// /metrics endpoint. See go/metrics for details.
-	servicemonitor: ok.ServiceMonitor(app.name, app.namespace) {
-		target_service:: $.service,
-		metadata+: {
-			labels+: sharedLabels,
-		},
-	},
 	// Default configuration for the service, managed by stencil.
 	// all other configuration should be done in the
 	// testing.config.jsonnet file
@@ -234,6 +226,14 @@ local all = {
 // nonDevelopmentObjects defines objects for staging/production environments.
 // Note: The vault secrets here are not related to the development vault secrets operator.
 local nonDevelopmentObjects = {
+  // ServiceMonitor tells the Prometheus operator to scrape this service's
+  // /metrics endpoint. See go/metrics for details.
+	servicemonitor: ok.ServiceMonitor(app.name, app.namespace) {
+		target_service:: $.service,
+		metadata+: {
+			labels+: sharedLabels,
+		},
+	},
 };
 
 // These secrets will be included in dev by default, they are fetched from vault.

--- a/templates/.snapshots/TestRenderDeploymentJsonnet-deployments-appname-app.jsonnet.tpl-deployments-testing-testing.jsonnet.snapshot
+++ b/templates/.snapshots/TestRenderDeploymentJsonnet-deployments-appname-app.jsonnet.tpl-deployments-testing-testing.jsonnet.snapshot
@@ -65,6 +65,14 @@ local all = {
 		},
 		spec+: { maxUnavailable: '15%' },
 	},
+	// ServiceMonitor tells the Prometheus operator to scrape this service's
+	// /metrics endpoint. See go/metrics for details.
+	servicemonitor: ok.ServiceMonitor(app.name, app.namespace) {
+		target_service:: $.service,
+		metadata+: {
+			labels+: sharedLabels,
+		},
+	},
 	// Default configuration for the service, managed by stencil.
 	// all other configuration should be done in the
 	// testing.config.jsonnet file

--- a/templates/.snapshots/TestRenderDeploymentJsonnetWithHPA-deployments-appname-app.jsonnet.tpl-deployments-testing-testing.jsonnet.snapshot
+++ b/templates/.snapshots/TestRenderDeploymentJsonnetWithHPA-deployments-appname-app.jsonnet.tpl-deployments-testing-testing.jsonnet.snapshot
@@ -65,14 +65,6 @@ local all = {
 		},
 		spec+: { maxUnavailable: '15%' },
 	},
-	// ServiceMonitor tells the Prometheus operator to scrape this service's
-	// /metrics endpoint. See go/metrics for details.
-	servicemonitor: ok.ServiceMonitor(app.name, app.namespace) {
-		target_service:: $.service,
-		metadata+: {
-			labels+: sharedLabels,
-		},
-	},
 	// Default configuration for the service, managed by stencil.
 	// all other configuration should be done in the
 	// testing.config.jsonnet file
@@ -236,6 +228,14 @@ local all = {
 // nonDevelopmentObjects defines objects for staging/production environments.
 // Note: The vault secrets here are not related to the development vault secrets operator.
 local nonDevelopmentObjects = {
+  // ServiceMonitor tells the Prometheus operator to scrape this service's
+  // /metrics endpoint. See go/metrics for details.
+	servicemonitor: ok.ServiceMonitor(app.name, app.namespace) {
+		target_service:: $.service,
+		metadata+: {
+			labels+: sharedLabels,
+		},
+	},
   // HPA configuration/objects
   local hpaReplicasConfig = {
     staging: {

--- a/templates/.snapshots/TestRenderDeploymentJsonnetWithHPA-deployments-appname-app.jsonnet.tpl-deployments-testing-testing.jsonnet.snapshot
+++ b/templates/.snapshots/TestRenderDeploymentJsonnetWithHPA-deployments-appname-app.jsonnet.tpl-deployments-testing-testing.jsonnet.snapshot
@@ -65,6 +65,14 @@ local all = {
 		},
 		spec+: { maxUnavailable: '15%' },
 	},
+	// ServiceMonitor tells the Prometheus operator to scrape this service's
+	// /metrics endpoint. See go/metrics for details.
+	servicemonitor: ok.ServiceMonitor(app.name, app.namespace) {
+		target_service:: $.service,
+		metadata+: {
+			labels+: sharedLabels,
+		},
+	},
 	// Default configuration for the service, managed by stencil.
 	// all other configuration should be done in the
 	// testing.config.jsonnet file

--- a/templates/.snapshots/TestRenderDeploymentJsonnet_AdditionalAllowedMetrics-deployments-appname-app.jsonnet.tpl-deployments-testing-testing.jsonnet.snapshot
+++ b/templates/.snapshots/TestRenderDeploymentJsonnet_AdditionalAllowedMetrics-deployments-appname-app.jsonnet.tpl-deployments-testing-testing.jsonnet.snapshot
@@ -67,6 +67,14 @@ local all = {
 		},
 		spec+: { maxUnavailable: '15%' },
 	},
+	// ServiceMonitor tells the Prometheus operator to scrape this service's
+	// /metrics endpoint. See go/metrics for details.
+	servicemonitor: ok.ServiceMonitor(app.name, app.namespace) {
+		target_service:: $.service,
+		metadata+: {
+			labels+: sharedLabels,
+		},
+	},
 	// Default configuration for the service, managed by stencil.
 	// all other configuration should be done in the
 	// testing.config.jsonnet file

--- a/templates/.snapshots/TestRenderDeploymentJsonnet_AdditionalAllowedMetrics-deployments-appname-app.jsonnet.tpl-deployments-testing-testing.jsonnet.snapshot
+++ b/templates/.snapshots/TestRenderDeploymentJsonnet_AdditionalAllowedMetrics-deployments-appname-app.jsonnet.tpl-deployments-testing-testing.jsonnet.snapshot
@@ -67,14 +67,6 @@ local all = {
 		},
 		spec+: { maxUnavailable: '15%' },
 	},
-	// ServiceMonitor tells the Prometheus operator to scrape this service's
-	// /metrics endpoint. See go/metrics for details.
-	servicemonitor: ok.ServiceMonitor(app.name, app.namespace) {
-		target_service:: $.service,
-		metadata+: {
-			labels+: sharedLabels,
-		},
-	},
 	// Default configuration for the service, managed by stencil.
 	// all other configuration should be done in the
 	// testing.config.jsonnet file
@@ -236,6 +228,14 @@ local all = {
 // nonDevelopmentObjects defines objects for staging/production environments.
 // Note: The vault secrets here are not related to the development vault secrets operator.
 local nonDevelopmentObjects = {
+  // ServiceMonitor tells the Prometheus operator to scrape this service's
+  // /metrics endpoint. See go/metrics for details.
+	servicemonitor: ok.ServiceMonitor(app.name, app.namespace) {
+		target_service:: $.service,
+		metadata+: {
+			labels+: sharedLabels,
+		},
+	},
 };
 
 // These secrets will be included in dev by default, they are fetched from vault.

--- a/templates/.snapshots/TestRenderDeploymentJsonnet_Canary-deployments-appname-app.jsonnet.tpl-deployments-testing-testing.jsonnet.snapshot
+++ b/templates/.snapshots/TestRenderDeploymentJsonnet_Canary-deployments-appname-app.jsonnet.tpl-deployments-testing-testing.jsonnet.snapshot
@@ -100,14 +100,6 @@ local all = {
 		},
 		spec+: { maxUnavailable: '15%' },
 	},
-	// ServiceMonitor tells the Prometheus operator to scrape this service's
-	// /metrics endpoint. See go/metrics for details.
-	servicemonitor: ok.ServiceMonitor(app.name, app.namespace) {
-		target_service:: $.service,
-		metadata+: {
-			labels+: sharedLabels,
-		},
-	},
 	// Default configuration for the service, managed by stencil.
 	// all other configuration should be done in the
 	// testing.config.jsonnet file
@@ -274,6 +266,14 @@ local all = {
 // nonDevelopmentObjects defines objects for staging/production environments.
 // Note: The vault secrets here are not related to the development vault secrets operator.
 local nonDevelopmentObjects = {
+  // ServiceMonitor tells the Prometheus operator to scrape this service's
+  // /metrics endpoint. See go/metrics for details.
+	servicemonitor: ok.ServiceMonitor(app.name, app.namespace) {
+		target_service:: $.service,
+		metadata+: {
+			labels+: sharedLabels,
+		},
+	},
   // ArgoRollouts objects
 	service_canary: ok.Service(app.name + '-canary', app.namespace) {
 		target_pod:: $.deployment.spec.template,

--- a/templates/.snapshots/TestRenderDeploymentJsonnet_Canary-deployments-appname-app.jsonnet.tpl-deployments-testing-testing.jsonnet.snapshot
+++ b/templates/.snapshots/TestRenderDeploymentJsonnet_Canary-deployments-appname-app.jsonnet.tpl-deployments-testing-testing.jsonnet.snapshot
@@ -100,6 +100,14 @@ local all = {
 		},
 		spec+: { maxUnavailable: '15%' },
 	},
+	// ServiceMonitor tells the Prometheus operator to scrape this service's
+	// /metrics endpoint. See go/metrics for details.
+	servicemonitor: ok.ServiceMonitor(app.name, app.namespace) {
+		target_service:: $.service,
+		metadata+: {
+			labels+: sharedLabels,
+		},
+	},
 	// Default configuration for the service, managed by stencil.
 	// all other configuration should be done in the
 	// testing.config.jsonnet file

--- a/templates/.snapshots/TestRenderDeploymentJsonnet_Canary_emptyServiceActivities-deployments-appname-app.jsonnet.tpl-deployments-testing-testing.jsonnet.snapshot
+++ b/templates/.snapshots/TestRenderDeploymentJsonnet_Canary_emptyServiceActivities-deployments-appname-app.jsonnet.tpl-deployments-testing-testing.jsonnet.snapshot
@@ -72,6 +72,14 @@ local all = {
 		},
 		spec+: { maxUnavailable: '15%' },
 	},
+	// ServiceMonitor tells the Prometheus operator to scrape this service's
+	// /metrics endpoint. See go/metrics for details.
+	servicemonitor: ok.ServiceMonitor(app.name, app.namespace) {
+		target_service:: $.service,
+		metadata+: {
+			labels+: sharedLabels,
+		},
+	},
 	// Default configuration for the service, managed by stencil.
 	// all other configuration should be done in the
 	// testing.config.jsonnet file

--- a/templates/.snapshots/TestRenderDeploymentJsonnet_Canary_emptyServiceActivities-deployments-appname-app.jsonnet.tpl-deployments-testing-testing.jsonnet.snapshot
+++ b/templates/.snapshots/TestRenderDeploymentJsonnet_Canary_emptyServiceActivities-deployments-appname-app.jsonnet.tpl-deployments-testing-testing.jsonnet.snapshot
@@ -72,14 +72,6 @@ local all = {
 		},
 		spec+: { maxUnavailable: '15%' },
 	},
-	// ServiceMonitor tells the Prometheus operator to scrape this service's
-	// /metrics endpoint. See go/metrics for details.
-	servicemonitor: ok.ServiceMonitor(app.name, app.namespace) {
-		target_service:: $.service,
-		metadata+: {
-			labels+: sharedLabels,
-		},
-	},
 	// Default configuration for the service, managed by stencil.
 	// all other configuration should be done in the
 	// testing.config.jsonnet file
@@ -241,6 +233,14 @@ local all = {
 // nonDevelopmentObjects defines objects for staging/production environments.
 // Note: The vault secrets here are not related to the development vault secrets operator.
 local nonDevelopmentObjects = {
+  // ServiceMonitor tells the Prometheus operator to scrape this service's
+  // /metrics endpoint. See go/metrics for details.
+	servicemonitor: ok.ServiceMonitor(app.name, app.namespace) {
+		target_service:: $.service,
+		metadata+: {
+			labels+: sharedLabels,
+		},
+	},
   // ArgoRollouts objects
 	service_canary: ok.Service(app.name + '-canary', app.namespace) {
 		target_pod:: $.deployment.spec.template,

--- a/templates/deployments/appname/app.jsonnet.tpl
+++ b/templates/deployments/appname/app.jsonnet.tpl
@@ -132,6 +132,14 @@ local all = {
 		},
 		spec+: { maxUnavailable: '15%' },
 	},
+	// ServiceMonitor tells the Prometheus operator to scrape this service's
+	// /metrics endpoint. See go/metrics for details.
+	servicemonitor: ok.ServiceMonitor(app.name, app.namespace) {
+		target_service:: $.service,
+		metadata+: {
+			labels+: sharedLabels,
+		},
+	},
 	// Default configuration for the service, managed by stencil.
 	// all other configuration should be done in the
 	// {{ $appName }}.config.jsonnet file

--- a/templates/deployments/appname/app.jsonnet.tpl
+++ b/templates/deployments/appname/app.jsonnet.tpl
@@ -132,14 +132,6 @@ local all = {
 		},
 		spec+: { maxUnavailable: '15%' },
 	},
-	// ServiceMonitor tells the Prometheus operator to scrape this service's
-	// /metrics endpoint. See go/metrics for details.
-	servicemonitor: ok.ServiceMonitor(app.name, app.namespace) {
-		target_service:: $.service,
-		metadata+: {
-			labels+: sharedLabels,
-		},
-	},
 	// Default configuration for the service, managed by stencil.
 	// all other configuration should be done in the
 	// {{ $appName }}.config.jsonnet file
@@ -367,6 +359,15 @@ local all = {
 // nonDevelopmentObjects defines objects for staging/production environments.
 // Note: The vault secrets here are not related to the development vault secrets operator.
 local nonDevelopmentObjects = {
+  // ServiceMonitor tells the Prometheus operator to scrape this service's
+  // /metrics endpoint. See go/metrics for details.
+	servicemonitor: ok.ServiceMonitor(app.name, app.namespace) {
+		target_service:: $.service,
+		metadata+: {
+			labels+: sharedLabels,
+		},
+	},
+
   {{- if (stencil.ApplyTemplate "vaultSecrets" | fromYaml).secrets }}
   // VaultSecrets to be deployed
 	{{- range $secretPath := (stencil.ApplyTemplate "vaultSecrets" | fromYaml).secrets }}


### PR DESCRIPTION
## what
add ServiceMonitor custom resource to app.jsonnet. one-liner target app service. prometheus operator scrape /metrics.

## why
FND-956. restencil get new custom resource -> metrics flow via prometheus.

## DO NOT MERGE yet
block until observability repo released. need prometheus operator CRD present in cluster or restencil fail. require:
- min: staging released
- prefer: all bentos released

merge after obs release confirmed.

## test
regen 5 jsonnet snapshots. all template tests pass.