### PR TITLE
fix: limit the files that are included in the ruby client gem build

### DIFF
--- a/templates/api/clients/ruby/Gemfile.tpl
+++ b/templates/api/clients/ruby/Gemfile.tpl
@@ -1,7 +1,7 @@
 {{- $_ := stencil.ApplyTemplate "skipGrpcClient" "ruby" -}}
 source 'https://rubygems.org'
 
-# Declare your gem's dependencies in github_stats.gemspec.
+# Declare your gem's dependencies in client.gemspec.
 # Bundler will treat runtime dependencies like base dependencies, and
 # development dependencies will be added by default to the :development group.
 gemspec

--- a/templates/api/clients/ruby/client.gemspec.tpl
+++ b/templates/api/clients/ruby/client.gemspec.tpl
@@ -17,7 +17,7 @@ Gem::Specification.new do |spec|
 
   spec.required_ruby_version = Gem::Requirement.new(">= {{ stencil.Arg "versions.grpcClients.ruby" }}")
   spec.files = Dir.chdir(File.expand_path(__dir__)) do
-    `git ls-files -z`.split("\x0").reject { |f| f.match(%r{^(test|spec|features)/}) }
+    `git ls-files -z lib`.split("\x0")
   end
   spec.require_paths = ["lib", "lib/{{ .Config.Name }}_client"]
   spec.add_dependency 'grpc', '~> 1.72'


### PR DESCRIPTION
<!--
  !!!! README !!!! Please fill this out.

  Please follow conventional commit naming conventions:

  https://www.conventionalcommits.org/en/v1.0.0/#summary
-->

Please read [CONTRIBUTING.md](CONTRIBUTING.md) for additional information on contributing to this repository!

<!-- A short description of what your PR does and what it solves. -->
## What this PR does / why we need it

The PC team frequently receives security tickets where Wiz identifies old dependencies as vulnerable. There are many false positives in those reports because Wiz decides to scan the dependency files of our dependencies, which lists gems and versions that are not actually installed by flagship.

Here's an example gem and the files that are installed in the flagship docker image:

```
nobody@7817ea4ac271:/usr/src/app/server/vendor/bundle/ruby/3.4.0/gems$ find orgapi_client-1.23.0/ | sort
orgapi_client-1.23.0/
orgapi_client-1.23.0/Gemfile
orgapi_client-1.23.0/Gemfile.lock
orgapi_client-1.23.0/Rakefile
orgapi_client-1.23.0/client.gemspec
orgapi_client-1.23.0/lib
orgapi_client-1.23.0/lib/orgapi_client
orgapi_client-1.23.0/lib/orgapi_client.rb
orgapi_client-1.23.0/lib/orgapi_client/client.rb
orgapi_client-1.23.0/lib/orgapi_client/orgapi_pb.rb
orgapi_client-1.23.0/lib/orgapi_client/orgapi_services_pb.rb
orgapi_client-1.23.0/lib/orgapi_client/state_pb.rb
orgapi_client-1.23.0/lib/orgapi_client/version.rb
```

We only need the files inside of the `lib` directory. The gem's metadata is bundled in the `.gem` file separately from the data. The `Gemfile.lock` lists versions of the `grpc` gem that are old and not actually installed by flagship, confusing Wiz.

Looking through all the gems that flagship install, only `dsng_client` seems to be including files outside of the `lib/` directory that look like they might be in use.

```
nobody@7817ea4ac271:/usr/src/app/server/vendor/bundle/ruby/3.4.0/gems$ ls dsng_client-1.182.1/
Gemfile  Gemfile.lock  Rakefile  client.gemspec  lib  settings  syncinstanceconfig
```

I did a cursory search in the flagship codebase and I don't think the files inside of `syncinstanceconfig` or `settings` are actually loaded at any point. Even if they are then this setup is very unconventional and brittle, and should be changed anyway. I will reach out and discuss with the sync team to see if we can clean this up.

There are other gems that include these files, including third party gems that we have no control over. This change will help us with the bulk of the internal issues though and reduce the false positives in Wiz.

```
nobody@7817ea4ac271:/usr/src/app/server/vendor/bundle/ruby/3.4.0/gems$ find . -name Gemfile.lock | sort
./ambassador_client-1.34.7/Gemfile.lock
./analytics-ruby-2.0.13/Gemfile.lock
./audits-client-1.0.1/Gemfile.lock
./brakeman-7.0.2/bundle/ruby/3.1.0/gems/unicode-emoji-4.0.4/Gemfile.lock
./builder-3.3.0/Gemfile.lock
./bulkworkflow_client-1.141.9/Gemfile.lock
./clerk-1.9.3/Gemfile.lock
./clicktrack_client-0.35.0/Gemfile.lock
./commitbridge_client-1.134.6/Gemfile.lock
./compliance_client-1.61.0/Gemfile.lock
./content_client-1.116.0/Gemfile.lock
./dsng_client-1.182.1/Gemfile.lock
./dsng_client-1.182.1/settings/Gemfile.lock
./dsng_client-1.182.1/syncinstanceconfig/Gemfile.lock
./dsngmapping_client-1.201.1/Gemfile.lock
./dsngpoller_client-1.113.5/Gemfile.lock
./eventkeeper_client-1.122.0/Gemfile.lock
./flagship-clerk-stubs-1.389.0/Gemfile.lock
./forecast_client-1.30.0/Gemfile.lock
./gearbox_client-1.673.0/Gemfile.lock
./governance_client-1.266.3/Gemfile.lock
./governancelib_client-1.165.1/Gemfile.lock
./hotswap_client-1.20.1/Gemfile.lock
./imports_client-1.47.3/Gemfile.lock
./json_api_model-0.5.0/Gemfile.lock
./kaiafrontdoor_client-1.235.1/Gemfile.lock
./kaiagateway_client-1.37.0/Gemfile.lock
./kaiaofflineimport_client-1.154.1/Gemfile.lock
./lichee_client-1.236.0/Gemfile.lock
./lint_roller-1.1.0/Gemfile.lock
./mailing_search-client-0.0.2/Gemfile.lock
./mailroomapi_client-1.26.0/Gemfile.lock
./mailroombackoffice_client-1.144.1/Gemfile.lock
./marathon_client-1.97.0/Gemfile.lock
./mint_client-1.77.10/Gemfile.lock
./muse_client-1.73.0/Gemfile.lock
./notifications_client-1.68.3/Gemfile.lock
./oats_client-1.33.0/Gemfile.lock
./oracle_client-1.68.0/Gemfile.lock
./orexservice_client-1.218.2/Gemfile.lock
./orgapi_client-1.23.0/Gemfile.lock
./orgservice_client-1.217.0/Gemfile.lock
./os-1.1.4/Gemfile.lock
./passkey_verification-client-0.3.0/Gemfile.lock
./pigeon_client-1.25.2/Gemfile.lock
./ppsgateway_client-1.194.1/Gemfile.lock
./prospector_client-1.499.1/Gemfile.lock
./protoapi_client-1.190.0/Gemfile.lock
./railroady-1.5.3/Gemfile.lock
./scheduler_client-1.77.1/Gemfile.lock
./searchstore_client-1.497.1/Gemfile.lock
./stonehenge_client-1.149.4/Gemfile.lock
./tailor_client-1.181.0/Gemfile.lock
./unicode-emoji-4.2.0/Gemfile.lock
./whoami_client-1.46.1/Gemfile.lock
nobody@7817ea4ac271:/usr/src/app/server/vendor/bundle/ruby/3.4.0/gems$ find . -name package-lock.json
./clerk-1.9.3/package-lock.json
nobody@7817ea4ac271:/usr/src/app/server/vendor/bundle/ruby/3.4.0/gems$ find . -name yarn.lock
./clerk-1.9.3/yarn.lock
./flagship-clerk-stubs-1.389.0/yarn.lock
```

<!-- <<Stencil::Block(jiraPrefix)>> -->

## Jira ID

https://outreach-io.atlassian.net/browse/STAR-5301

<!-- <</Stencil::Block>> -->

<!-- Notes that may be helpful for anyone reviewing this PR -->
## Notes for your reviewers

<!-- <<Stencil::Block(custom)>> -->

<!-- <</Stencil::Block>> -->
