### PR TITLE
feat(goreleaser): allow per-command goos/goarch overrides

### DIFF
--- a/manifest.yaml
+++ b/manifest.yaml
@@ -67,6 +67,19 @@ arguments:
               unmanaged:
                 type: boolean
                 description: If true, stencil will not generate an entrypoint go file for this CLI (`cmd/<name>/<name>.go`), but still will build and distribute it.
+              goos:
+                type: array
+                items:
+                  type: string
+                description: |-
+                  Operating systems to build this command for. Defaults to ["linux", "darwin"]. Narrow this to just ["linux"] for
+                  binaries that only ever run in-cluster; goreleaser builds every goos/goarch combination in parallel, so dropping
+                  unused targets meaningfully reduces peak memory during a release.
+              goarch:
+                type: array
+                items:
+                  type: string
+                description: Architectures to build this command for. Defaults to ["amd64", "arm64"].
     description: List of CLI commands to generate for this repository
   grpcClients:
     schema:

--- a/templates/.goreleaser.yml.tpl
+++ b/templates/.goreleaser.yml.tpl
@@ -17,11 +17,13 @@ builds:
     id: &name {{ $cmdName }}
     binary: *name
     goos:
-      - linux
-      - darwin
+      {{- range ($opts.goos | default (list "linux" "darwin")) }}
+      - {{ . }}
+      {{- end }}
     goarch:
-      - amd64
-      - arm64
+      {{- range ($opts.goarch | default (list "amd64" "arm64")) }}
+      - {{ . }}
+      {{- end }}
     ldflags:
       - '-w -s -X "github.com/getoutreach/gobox/pkg/app.Version=v{{ "{{" }} .Version {{ "}}" }}"'
       {{- if not $opts.delibird }}

--- a/templates/.snapshots/TestGoreleaserYmlCustomPlatforms-.goreleaser.yml.tpl-.goreleaser.yml.snapshot
+++ b/templates/.snapshots/TestGoreleaserYmlCustomPlatforms-.goreleaser.yml.tpl-.goreleaser.yml.snapshot
@@ -1,0 +1,64 @@
+(*codegen.File)(# yaml-language-server: $schema=https://goreleaser.com/static/schema.json
+before:
+  hooks:
+    - make dep
+builds:
+  - main: ./cmd/cmd1
+    id: &name cmd1
+    binary: *name
+    goos:
+      - linux
+      - darwin
+    goarch:
+      - amd64
+      - arm64
+    ldflags:
+      - '-w -s -X "github.com/getoutreach/gobox/pkg/app.Version=v{{ .Version }}"'
+      - '-X "main.HoneycombTracingKey={{ .Env.HONEYCOMB_APIKEY }}"'
+      - '-X "main.TeleforkAPIKey={{ .Env.TELEFORK_APIKEY }}"'
+    env:
+      - CGO_ENABLED=0
+      ## <<Stencil::Block(cmd1AdditionalEnv)>>
+      
+      ## <</Stencil::Block>>
+  - main: ./cmd/cmd2
+    id: &name cmd2
+    binary: *name
+    goos:
+      - linux
+    goarch:
+      - amd64
+      - arm64
+    ldflags:
+      - '-w -s -X "github.com/getoutreach/gobox/pkg/app.Version=v{{ .Version }}"'
+      - '-X "main.HoneycombTracingKey={{ .Env.HONEYCOMB_APIKEY }}"'
+      - '-X "main.TeleforkAPIKey={{ .Env.TELEFORK_APIKEY }}"'
+    env:
+      - CGO_ENABLED=0
+      ## <<Stencil::Block(cmd2AdditionalEnv)>>
+      
+      ## <</Stencil::Block>>
+  - main: ./cmd/cmd3
+    id: &name cmd3
+    binary: *name
+    goos:
+      - linux
+    goarch:
+      - amd64
+    ldflags:
+      - '-w -s -X "github.com/getoutreach/gobox/pkg/app.Version=v{{ .Version }}"'
+      - '-X "main.HoneycombTracingKey={{ .Env.HONEYCOMB_APIKEY }}"'
+      - '-X "main.TeleforkAPIKey={{ .Env.TELEFORK_APIKEY }}"'
+    env:
+      - CGO_ENABLED=0
+      ## <<Stencil::Block(cmd3AdditionalEnv)>>
+      
+      ## <</Stencil::Block>>
+
+archives: []
+checksum:
+  name_template: 'checksums.txt'
+release:
+  # We handle releasing via semantic-release
+  disable: true
+)

--- a/templates/main_test.go
+++ b/templates/main_test.go
@@ -319,6 +319,27 @@ func TestGoreleaserYml(t *testing.T) {
 	st.Run(stenciltest.RegenerateSnapshots())
 }
 
+func TestGoreleaserYmlCustomPlatforms(t *testing.T) {
+	st := stenciltest.New(t, ".goreleaser.yml.tpl", libraryTmpls...)
+	st.Args(map[string]interface{}{
+		"commands": []interface{}{
+			"cmd1",
+			map[string]interface{}{
+				"cmd2": map[string]interface{}{
+					"goos": []interface{}{"linux"},
+				},
+			},
+			map[string]interface{}{
+				"cmd3": map[string]interface{}{
+					"goos":   []interface{}{"linux"},
+					"goarch": []interface{}{"amd64"},
+				},
+			},
+		},
+	})
+	st.Run(stenciltest.RegenerateSnapshots())
+}
+
 func TestRenderGolangcilintYaml(t *testing.T) {
 	st := stenciltest.New(t, "scripts/golangci.yml.tpl", libraryTmpls...)
 	st.Args(map[string]interface{}{


### PR DESCRIPTION
## Problem

`goreleaser` builds every `goos`/`goarch` combination in parallel. For a command with a large dependency tree — e.g. anything pulling in `clerkcommons`' generated protobuf packages — four concurrent `compile` processes can exhaust CI memory and get SIGKILL'd by the OOM killer:

```
⨯ release failed  error=failed to build for darwin_amd64_v1: exit status 1:
  github.com/getoutreach/clerkcommons/pkg/schema/proto/outreach/application:
  .../pkg/tool/linux_amd64/compile: signal: killed
```

Commands that only ever run in-cluster (cleanup jobs, migrations, cron workers) have no reason to build darwin binaries at all.

## Change

Adds optional `goos` and `goarch` properties to the `commands` arg, letting a repo narrow the build matrix per command:

```yaml
commands:
  - my-cli                 # unchanged: linux+darwin, amd64+arm64
  - retention-data-cleaner:
      goos: [linux]        # in-cluster only
```

Defaults are unchanged, so this is a no-op for every existing repo.

## Testing

- Existing `TestGoreleaserYml` snapshot is unchanged, confirming default behavior is preserved.
- New `TestGoreleaserYmlCustomPlatforms` snapshot covers the default, `goos`-only, and `goos`+`goarch` cases.

_Generated with AI assistance._