### PR TITLE
feat(golangci): deny archived getoutreach/async in favor of gobox/pkg/async

### DIFF
--- a/scripts/golangci.yml
+++ b/scripts/golangci.yml
@@ -15,6 +15,7 @@ linters:
   enable:
     - bodyclose
     - copyloopvar # Detects places where loop variables are copied.
+    - depguard
     - dogsled
     - errcheck
     - errorlint
@@ -37,6 +38,14 @@ linters:
     # - unused # Previously suppressed by --fast in v1, disabling for now to avoid noise
     - whitespace
   settings:
+    depguard:
+      rules:
+        main:
+          files:
+            - "$all"
+          deny:
+            - pkg: "github.com/getoutreach/async/pkg/async"
+              desc: "archived since 2022; use github.com/getoutreach/gobox/pkg/async instead"
     dupl:
       threshold: 100
     errcheck:

--- a/templates/.snapshots/TestRenderGolangcilintYaml-scripts-golangci.yml.tpl-scripts-golangci.yml.snapshot
+++ b/templates/.snapshots/TestRenderGolangcilintYaml-scripts-golangci.yml.tpl-scripts-golangci.yml.snapshot
@@ -15,6 +15,7 @@ linters:
   enable:
     - bodyclose
     - copyloopvar # Detects places where loop variables are copied.
+    - depguard
     - dogsled
     - errcheck
     - errorlint
@@ -37,6 +38,14 @@ linters:
     # - unused # Previously suppressed by --fast in v1, disabling for now to avoid noise
     - whitespace
   settings:
+    depguard:
+      rules:
+        main:
+          files:
+            - "$all"
+          deny:
+            - pkg: "github.com/getoutreach/async/pkg/async"
+              desc: "archived since 2022; use github.com/getoutreach/gobox/pkg/async instead"
     dupl:
       threshold: 100
     errcheck:

--- a/templates/.snapshots/TestRenderGolangcilintYamlGofumpt-scripts-golangci.yml.tpl-scripts-golangci.yml.snapshot
+++ b/templates/.snapshots/TestRenderGolangcilintYamlGofumpt-scripts-golangci.yml.tpl-scripts-golangci.yml.snapshot
@@ -15,6 +15,7 @@ linters:
   enable:
     - bodyclose
     - copyloopvar # Detects places where loop variables are copied.
+    - depguard
     - dogsled
     - errcheck
     - errorlint
@@ -37,6 +38,14 @@ linters:
     # - unused # Previously suppressed by --fast in v1, disabling for now to avoid noise
     - whitespace
   settings:
+    depguard:
+      rules:
+        main:
+          files:
+            - "$all"
+          deny:
+            - pkg: "github.com/getoutreach/async/pkg/async"
+              desc: "archived since 2022; use github.com/getoutreach/gobox/pkg/async instead"
     dupl:
       threshold: 100
     errcheck:

--- a/templates/.snapshots/TestRenderGolangcilintYamlStrict-scripts-golangci.yml.tpl-scripts-golangci.yml.snapshot
+++ b/templates/.snapshots/TestRenderGolangcilintYamlStrict-scripts-golangci.yml.tpl-scripts-golangci.yml.snapshot
@@ -15,6 +15,7 @@ linters:
   enable:
     - bodyclose
     - copyloopvar # Detects places where loop variables are copied.
+    - depguard
     - dogsled
     - errcheck
     - errorlint
@@ -81,6 +82,14 @@ linters:
     - wastedassign
     - zerologlint
   settings:
+    depguard:
+      rules:
+        main:
+          files:
+            - "$all"
+          deny:
+            - pkg: "github.com/getoutreach/async/pkg/async"
+              desc: "archived since 2022; use github.com/getoutreach/gobox/pkg/async instead"
     dupl:
       threshold: 100
     errcheck:

--- a/templates/scripts/golangci.yml.tpl
+++ b/templates/scripts/golangci.yml.tpl
@@ -15,6 +15,7 @@ linters:
   enable:
     - bodyclose
     - copyloopvar # Detects places where loop variables are copied.
+    - depguard
     - dogsled
     - errcheck
     - errorlint
@@ -87,6 +88,14 @@ linters:
     - zerologlint
 {{- end }}
   settings:
+    depguard:
+      rules:
+        main:
+          files:
+            - "$all"
+          deny:
+            - pkg: "github.com/getoutreach/async/pkg/async"
+              desc: "archived since 2022; use github.com/getoutreach/gobox/pkg/async instead"
     dupl:
       threshold: 100
     errcheck:


### PR DESCRIPTION
## What this PR does / why we need it

Adds the `depguard` linter to the golangci-lint config template, enabled unconditionally (not gated by `go.linters.strict`). It denies imports of `github.com/getoutreach/async/pkg/async` in favor of `github.com/getoutreach/gobox/pkg/async`.

`getoutreach/async` was deprecated back in Feb 2022 ("feat: deprecate in favor of gobox/pkg/async") and the repo is now archived, yet at least 24 downstream repos (28 by GitHub code search, likely more) still import it. Given the deprecation has been outstanding for 4.5 years, this is enabled at all lint tiers rather than only under `strict`.

Errors look like this:

```
internal/foo/bar.go:12:2: import 'github.com/getoutreach/async/pkg/async' is not allowed from list 'main': archived since 2022; use github.com/getoutreach/gobox/pkg/async instead (depguard)
        "github.com/getoutreach/async/pkg/async"
        ^
```