### PR TITLE
fix: migrate gRPC Node.js client CircleCI jobs to this module

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -15,6 +15,7 @@ require (
 	github.com/pkg/errors v0.9.1
 	github.com/sirupsen/logrus v1.9.4
 	golang.org/x/mod v0.38.0
+	gotest.tools/v3 v3.5.2
 )
 
 require (
@@ -106,6 +107,5 @@ require (
 	google.golang.org/grpc v1.82.1 // indirect
 	google.golang.org/protobuf v1.36.11 // indirect
 	gopkg.in/warnings.v0 v0.1.2 // indirect
-	gotest.tools/v3 v3.5.2 // indirect
 	sigs.k8s.io/yaml v1.6.0 // indirect
 )

--- a/manifest.yaml
+++ b/manifest.yaml
@@ -3,6 +3,7 @@ name: github.com/getoutreach/stencil-golang
 modules:
   - name: github.com/getoutreach/devbase
     version: ">=2.21.0"
+  - name: github.com/getoutreach/stencil-circleci
 type: templates,extension
 arguments:
   # The following terraform.datadog fields are used for Canary deployments in app.jsonnet.tpl

--- a/templates/.circleci/config.yml.tpl
+++ b/templates/.circleci/config.yml.tpl
@@ -1,0 +1,50 @@
+{{ file.Skip "Virtual file for CircleCI config via stencil-circleci" }}
+
+{{- define "gRPCNodeJSClientTestWorkflowJob" }}
+{{- $executorName := "" }}
+{{- if contains "amazonaws.com" .Runtime.Box.Docker.ImagePullRegistry }}
+{{- $executorName = "testbed-docker-aws" }}
+{{- else }}
+{{- $executorName = "testbed-docker" }}
+{{- end }}
+shared/test_node_client:
+  context:
+    {{- with .Runtime.Box.CI.CircleCI.Contexts }}
+    {{- if .AWS }}
+    # AWS Authentication Context
+    - {{ .AWS }}
+    {{- end }}
+    {{- if .Github }}
+    # Github Authentication Context
+    - {{ .Github }}
+    {{- end }}
+    {{- if .Docker }}
+    # Docker Authentication Context
+    - {{ .Docker }}
+    {{- end }}
+    {{- if .ExtraContexts }}
+    # Extra Contexts from box config
+    {{- end }}
+    {{- range .ExtraContexts }}
+    - {{ . }}
+    {{- end }}
+    {{- end }}
+  {{- if not (stencil.Arg "oss") }}
+  executor_name: {{ $executorName }}
+  {{- end }}
+  steps: []
+{{- end }}
+
+{{ define "releaseNodeJSParam" }}
+node_client: true
+{{- end }}
+
+{{ define "releaseNodeJSRequires" }}
+- shared/test_node_client
+{{- end }}
+
+{{- if and (or (not (stencil.Arg "service")) (has "grpc" (stencil.Arg "serviceActivities"))) (has "node" (stencil.Arg "grpcClients")) }}
+{{- stencil.AddToModuleHook "github.com/getoutreach/stencil-circleci" "workflows.release.jobs" (list (fromYaml (stencil.ApplyTemplate "gRPCNodeJSClientTestWorkflowJob"))) }}
+{{- stencil.AddToModuleHook "github.com/getoutreach/stencil-circleci" "workflows.release.release.params" (list (stencil.ApplyTemplate "releaseNodeJSParam")) }}
+{{- stencil.AddToModuleHook "github.com/getoutreach/stencil-circleci" "workflows.release.release.requires" (fromYaml (stencil.ApplyTemplate "releaseNodeJSRequires")) }}
+{{- end }}

--- a/templates/.snapshots/TestRenderDeploymentDockerfile-deployments-appname-Dockerfile.tpl-deployments-testing-Dockerfile.snapshot
+++ b/templates/.snapshots/TestRenderDeploymentDockerfile-deployments-appname-Dockerfile.tpl-deployments-testing-Dockerfile.snapshot
@@ -28,7 +28,7 @@ RUN --mount=type=ssh --mount=type=cache,target=/go/pkg --mount=type=cache,target
 FROM registry.example.com/foo/alpine:3.1
 ENTRYPOINT ["/usr/local/bin/testing"]
 
-LABEL "io.outreach.reporting_team"="fnd-seal"
+LABEL "io.outreach.reporting_team"="org-team"
 LABEL "io.outreach.repo"="testing"
 
 # Add timezone information.

--- a/templates/.snapshots/TestRenderDeploymentDockerfileForCLI-deployments-appname-Dockerfile.tpl-deployments-testing-Dockerfile.snapshot
+++ b/templates/.snapshots/TestRenderDeploymentDockerfileForCLI-deployments-appname-Dockerfile.tpl-deployments-testing-Dockerfile.snapshot
@@ -28,7 +28,7 @@ RUN --mount=type=ssh --mount=type=cache,target=/go/pkg --mount=type=cache,target
 FROM registry.example.com/foo/alpine:3.1
 ENTRYPOINT ["/usr/local/bin/testing", "--skip-update"]
 
-LABEL "io.outreach.reporting_team"="fnd-seal"
+LABEL "io.outreach.reporting_team"="org-team"
 LABEL "io.outreach.repo"="testing"
 
 ## <<Stencil::Block(afterBuild)>>

--- a/templates/.snapshots/TestRenderDeploymentJsonnet-deployments-appname-app.jsonnet.tpl-deployments-testing-testing.jsonnet.snapshot
+++ b/templates/.snapshots/TestRenderDeploymentJsonnet-deployments-appname-app.jsonnet.tpl-deployments-testing-testing.jsonnet.snapshot
@@ -17,7 +17,7 @@ local isLocalDev = app.environment == 'local_development';
 local sharedLabels = {
 	repo: app.name,
 	bento: app.bento,
-	reporting_team: '',
+	reporting_team: 'org-team',
 };
 
 local all = {

--- a/templates/.snapshots/TestRenderDeploymentJsonnetWithHPA-deployments-appname-app.jsonnet.tpl-deployments-testing-testing.jsonnet.snapshot
+++ b/templates/.snapshots/TestRenderDeploymentJsonnetWithHPA-deployments-appname-app.jsonnet.tpl-deployments-testing-testing.jsonnet.snapshot
@@ -17,7 +17,7 @@ local isLocalDev = app.environment == 'local_development';
 local sharedLabels = {
 	repo: app.name,
 	bento: app.bento,
-	reporting_team: '',
+	reporting_team: 'org-team',
 };
 
 local all = {

--- a/templates/.snapshots/TestRenderDeploymentJsonnet_AdditionalAllowedMetrics-deployments-appname-app.jsonnet.tpl-deployments-testing-testing.jsonnet.snapshot
+++ b/templates/.snapshots/TestRenderDeploymentJsonnet_AdditionalAllowedMetrics-deployments-appname-app.jsonnet.tpl-deployments-testing-testing.jsonnet.snapshot
@@ -17,7 +17,7 @@ local isLocalDev = app.environment == 'local_development';
 local sharedLabels = {
 	repo: app.name,
 	bento: app.bento,
-	reporting_team: '',
+	reporting_team: 'org-team',
 };
 
 local all = {

--- a/templates/.snapshots/TestRenderDeploymentJsonnet_Canary-deployments-appname-app.jsonnet.tpl-deployments-testing-testing.jsonnet.snapshot
+++ b/templates/.snapshots/TestRenderDeploymentJsonnet_Canary-deployments-appname-app.jsonnet.tpl-deployments-testing-testing.jsonnet.snapshot
@@ -17,7 +17,7 @@ local isLocalDev = app.environment == 'local_development';
 local sharedLabels = {
 	repo: app.name,
 	bento: app.bento,
-	reporting_team: 'test:team',
+	reporting_team: 'org-team',
 };
 local deploymentMetrics = [
   argo.AnalysisMetricDatadog('pod-restart') {

--- a/templates/.snapshots/TestRenderDeploymentJsonnet_Canary_emptyServiceActivities-deployments-appname-app.jsonnet.tpl-deployments-testing-testing.jsonnet.snapshot
+++ b/templates/.snapshots/TestRenderDeploymentJsonnet_Canary_emptyServiceActivities-deployments-appname-app.jsonnet.tpl-deployments-testing-testing.jsonnet.snapshot
@@ -17,7 +17,7 @@ local isLocalDev = app.environment == 'local_development';
 local sharedLabels = {
 	repo: app.name,
 	bento: app.bento,
-	reporting_team: 'test:team',
+	reporting_team: 'org-team',
 };
 local deploymentMetrics = [
   argo.AnalysisMetricDatadog('pod-restart') {

--- a/templates/main_test.go
+++ b/templates/main_test.go
@@ -34,13 +34,13 @@ func TestRenderDeploymentConfig(t *testing.T) {
 }
 
 func TestRenderDeploymentJsonnet(t *testing.T) {
-	assertTemplateSnapshot(t, "deployments/appname/app.jsonnet.tpl", map[string]interface{}{
+	assertTemplateSnapshot(t, "deployments/appname/app.jsonnet.tpl", map[string]any{
 		"mixins": []interface{}{"c", "b", "a"}, // These should be sorted alphabetically in the snapshot
 	})
 }
 
 func TestRenderDeploymentJsonnet_Canary(t *testing.T) {
-	assertTemplateSnapshot(t, "deployments/appname/app.jsonnet.tpl", map[string]interface{}{
+	assertTemplateSnapshot(t, "deployments/appname/app.jsonnet.tpl", map[string]any{
 		"reportingTeam": "test:team",
 		"deployment": map[string]interface{}{
 			"strategy": "canary",
@@ -55,7 +55,7 @@ func TestRenderDeploymentJsonnet_Canary(t *testing.T) {
 }
 
 func TestRenderDeploymentJsonnet_Canary_emptyServiceActivities(t *testing.T) {
-	assertTemplateSnapshot(t, "deployments/appname/app.jsonnet.tpl", map[string]interface{}{
+	assertTemplateSnapshot(t, "deployments/appname/app.jsonnet.tpl", map[string]any{
 		"reportingTeam": "test:team",
 		"deployment": map[string]interface{}{
 			"strategy": "canary",
@@ -67,7 +67,7 @@ func TestRenderDeploymentJsonnet_Canary_emptyServiceActivities(t *testing.T) {
 }
 
 func TestRenderDeploymentJsonnetWithHPA(t *testing.T) {
-	assertTemplateSnapshot(t, "deployments/appname/app.jsonnet.tpl", map[string]interface{}{
+	assertTemplateSnapshot(t, "deployments/appname/app.jsonnet.tpl", map[string]any{
 		"hpa": map[string]interface{}{
 			"enabled":        true,
 			"cpuUtilization": 50,
@@ -98,7 +98,7 @@ func TestRenderDeploymentJsonnetWithHPA(t *testing.T) {
 }
 
 func TestRenderDeploymentJsonnet_AdditionalAllowedMetrics(t *testing.T) {
-	assertTemplateSnapshot(t, "deployments/appname/app.jsonnet.tpl", map[string]interface{}{
+	assertTemplateSnapshot(t, "deployments/appname/app.jsonnet.tpl", map[string]any{
 		"additionalAllowedMetrics": []interface{}{
 			"my_custom_counter",
 			"my_custom_histogram_bucket",
@@ -145,7 +145,7 @@ func TestRenderDeploymentDockerfileForCLI(t *testing.T) {
 }
 
 func TestRenderDependabot(t *testing.T) {
-	assertTemplateSnapshot(t, ".github/dependabot.yml.tpl", map[string]interface{}{
+	assertTemplateSnapshot(t, ".github/dependabot.yml.tpl", map[string]any{
 		"service":           true,
 		"serviceActivities": []interface{}{"grpc"},
 		"grpcClients":       []interface{}{"node"},
@@ -171,7 +171,7 @@ func TestMergeGoMod(t *testing.T) {
 }
 
 func TestGoModStanzaVersion(t *testing.T) {
-	st := newStencilTestWithGolangPlugin(t, "go.mod.tpl", map[string]interface{}{
+	st := newStencilTestWithGolangPlugin(t, "go.mod.tpl", map[string]any{
 		"go": map[string]interface{}{
 			"stanza": "1.19",
 		},
@@ -206,7 +206,7 @@ func TestDevspaceYaml(t *testing.T) {
 }
 
 func TestVSCodeLaunchConfig(t *testing.T) {
-	assertTemplateSnapshot(t, ".vscode/launch.json.tpl", map[string]interface{}{
+	assertTemplateSnapshot(t, ".vscode/launch.json.tpl", map[string]any{
 		"service": true,
 	})
 }
@@ -234,7 +234,7 @@ func TestVSCodeSettingsConfigGofumpt(t *testing.T) {
 }
 
 func TestGRPCServerRPC(t *testing.T) {
-	assertTemplateSnapshot(t, "internal/appName/rpc/rpc.go.tpl", map[string]interface{}{
+	assertTemplateSnapshot(t, "internal/appName/rpc/rpc.go.tpl", map[string]any{
 		"service": true,
 		"serviceActivities": []interface{}{
 			"grpc",
@@ -243,7 +243,7 @@ func TestGRPCServerRPC(t *testing.T) {
 }
 
 func TestGoreleaserYml(t *testing.T) {
-	assertTemplateSnapshot(t, ".goreleaser.yml.tpl", map[string]interface{}{
+	assertTemplateSnapshot(t, ".goreleaser.yml.tpl", map[string]any{
 		"commands": []interface{}{
 			"cmd1",
 			"cmd2",
@@ -255,7 +255,7 @@ func TestGoreleaserYml(t *testing.T) {
 }
 
 func TestRenderGolangcilintYaml(t *testing.T) {
-	assertTemplateSnapshot(t, "scripts/golangci.yml.tpl", map[string]interface{}{
+	assertTemplateSnapshot(t, "scripts/golangci.yml.tpl", map[string]any{
 		"lintroller": "platinum",
 	})
 }

--- a/templates/main_test.go
+++ b/templates/main_test.go
@@ -41,7 +41,6 @@ func TestRenderDeploymentJsonnet(t *testing.T) {
 
 func TestRenderDeploymentJsonnet_Canary(t *testing.T) {
 	assertTemplateSnapshot(t, "deployments/appname/app.jsonnet.tpl", map[string]any{
-		"reportingTeam": "test:team",
 		"deployment": map[string]interface{}{
 			"strategy": "canary",
 		},
@@ -56,7 +55,6 @@ func TestRenderDeploymentJsonnet_Canary(t *testing.T) {
 
 func TestRenderDeploymentJsonnet_Canary_emptyServiceActivities(t *testing.T) {
 	assertTemplateSnapshot(t, "deployments/appname/app.jsonnet.tpl", map[string]any{
-		"reportingTeam": "test:team",
 		"deployment": map[string]interface{}{
 			"strategy": "canary",
 		},
@@ -113,8 +111,7 @@ func TestRenderDeploymentOverride(t *testing.T) {
 func TestRenderDeploymentDockerfile(t *testing.T) {
 	fakeDockerPullRegistry(t)
 	assertTemplateSnapshot(t, "deployments/appname/Dockerfile.tpl", map[string]any{
-		"service":       true,
-		"reportingTeam": "fnd-seal",
+		"service": true,
 		// Setting versions to avoid needing to update snapshots every
 		// time default versions change.
 		"versions": map[string]any{
@@ -134,7 +131,6 @@ func TestRenderDeploymentDockerfileForCLI(t *testing.T) {
 		"deployments": map[string]any{
 			"buildContainerForCLI": true,
 		},
-		"reportingTeam": "fnd-seal",
 		// Setting versions to avoid needing to update snapshots every
 		// time default versions change.
 		"versions": map[string]any{

--- a/templates/main_test.go
+++ b/templates/main_test.go
@@ -2,18 +2,12 @@
 package main_test
 
 import (
-	"context"
 	"os"
 	"testing"
 
-	"github.com/getoutreach/stencil-golang/internal/plugin"
 	"github.com/getoutreach/stencil/pkg/stenciltest"
 	"github.com/magefile/mage/sh"
 )
-
-var libraryTmpls = []string{
-	"_helpers.tpl",
-}
 
 // fakeDockerPullRegistry sets the BOX_DOCKER_PULL_IMAGE_REGISTRY environment
 // variable to a fake value for the duration of the test.
@@ -26,34 +20,27 @@ func TestRenderAPIGoSuccess(t *testing.T) {
 	// NOTE: 2022-07-06 For the moment, we cannot change the `Name` field of
 	// the ServiceManifest used by the `Run()` method in stenciltest, which is
 	// why this test does not verify correct handling of odd service names.
-	st := stenciltest.New(t, "api/api.go.tpl", libraryTmpls...)
-	st.Run(stenciltest.RegenerateSnapshots())
+	assertTemplateSnapshot(t, "api/api.go.tpl", nil)
 }
 
 func TestOSSCopyright(t *testing.T) {
-	st := stenciltest.New(t, "cmd/main.go.tpl", libraryTmpls...)
-	st.Args(map[string]any{
+	assertTemplateSnapshot(t, "cmd/main.go.tpl", map[string]any{
 		"oss": true,
 	})
-	st.Run(stenciltest.RegenerateSnapshots())
 }
 
 func TestRenderDeploymentConfig(t *testing.T) {
-	st := stenciltest.New(t, "deployments/appname/app.config.jsonnet.tpl", libraryTmpls...)
-	st.Run(stenciltest.RegenerateSnapshots())
+	assertTemplateSnapshot(t, "deployments/appname/app.config.jsonnet.tpl", nil)
 }
 
 func TestRenderDeploymentJsonnet(t *testing.T) {
-	st := stenciltest.New(t, "deployments/appname/app.jsonnet.tpl", libraryTmpls...)
-	st.Args(map[string]interface{}{
+	assertTemplateSnapshot(t, "deployments/appname/app.jsonnet.tpl", map[string]interface{}{
 		"mixins": []interface{}{"c", "b", "a"}, // These should be sorted alphabetically in the snapshot
 	})
-	st.Run(stenciltest.RegenerateSnapshots())
 }
 
 func TestRenderDeploymentJsonnet_Canary(t *testing.T) {
-	st := stenciltest.New(t, "deployments/appname/app.jsonnet.tpl", libraryTmpls...)
-	st.Args(map[string]interface{}{
+	assertTemplateSnapshot(t, "deployments/appname/app.jsonnet.tpl", map[string]interface{}{
 		"reportingTeam": "test:team",
 		"deployment": map[string]interface{}{
 			"strategy": "canary",
@@ -65,12 +52,10 @@ func TestRenderDeploymentJsonnet_Canary(t *testing.T) {
 		},
 		"slack": "hello",
 	})
-	st.Run(stenciltest.RegenerateSnapshots())
 }
 
 func TestRenderDeploymentJsonnet_Canary_emptyServiceActivities(t *testing.T) {
-	st := stenciltest.New(t, "deployments/appname/app.jsonnet.tpl", libraryTmpls...)
-	st.Args(map[string]interface{}{
+	assertTemplateSnapshot(t, "deployments/appname/app.jsonnet.tpl", map[string]interface{}{
 		"reportingTeam": "test:team",
 		"deployment": map[string]interface{}{
 			"strategy": "canary",
@@ -79,12 +64,10 @@ func TestRenderDeploymentJsonnet_Canary_emptyServiceActivities(t *testing.T) {
 		"serviceActivities": []interface{}{},
 		"slack":             "hello",
 	})
-	st.Run(stenciltest.RegenerateSnapshots())
 }
 
 func TestRenderDeploymentJsonnetWithHPA(t *testing.T) {
-	st := stenciltest.New(t, "deployments/appname/app.jsonnet.tpl", libraryTmpls...)
-	st.Args(map[string]interface{}{
+	assertTemplateSnapshot(t, "deployments/appname/app.jsonnet.tpl", map[string]interface{}{
 		"hpa": map[string]interface{}{
 			"enabled":        true,
 			"cpuUtilization": 50,
@@ -112,29 +95,24 @@ func TestRenderDeploymentJsonnetWithHPA(t *testing.T) {
 		},
 		"enableReloader": true,
 	})
-	st.Run(stenciltest.RegenerateSnapshots())
 }
 
 func TestRenderDeploymentJsonnet_AdditionalAllowedMetrics(t *testing.T) {
-	st := stenciltest.New(t, "deployments/appname/app.jsonnet.tpl", libraryTmpls...)
-	st.Args(map[string]interface{}{
+	assertTemplateSnapshot(t, "deployments/appname/app.jsonnet.tpl", map[string]interface{}{
 		"additionalAllowedMetrics": []interface{}{
 			"my_custom_counter",
 			"my_custom_histogram_bucket",
 		},
 	})
-	st.Run(stenciltest.RegenerateSnapshots())
 }
 
 func TestRenderDeploymentOverride(t *testing.T) {
-	st := stenciltest.New(t, "deployments/appname/app.override.jsonnet.tpl", libraryTmpls...)
-	st.Run(stenciltest.RegenerateSnapshots())
+	assertTemplateSnapshot(t, "deployments/appname/app.override.jsonnet.tpl", nil)
 }
 
 func TestRenderDeploymentDockerfile(t *testing.T) {
 	fakeDockerPullRegistry(t)
-	st := stenciltest.New(t, "deployments/appname/Dockerfile.tpl", libraryTmpls...)
-	st.Args(map[string]any{
+	assertTemplateSnapshot(t, "deployments/appname/Dockerfile.tpl", map[string]any{
 		"service":       true,
 		"reportingTeam": "fnd-seal",
 		// Setting versions to avoid needing to update snapshots every
@@ -144,13 +122,11 @@ func TestRenderDeploymentDockerfile(t *testing.T) {
 			"alpine": "3.1",
 		},
 	})
-	st.Run(stenciltest.RegenerateSnapshots())
 }
 
 func TestRenderDeploymentDockerfileForCLI(t *testing.T) {
 	fakeDockerPullRegistry(t)
-	st := stenciltest.New(t, "deployments/appname/Dockerfile.tpl", libraryTmpls...)
-	st.Args(map[string]any{
+	assertTemplateSnapshot(t, "deployments/appname/Dockerfile.tpl", map[string]any{
 		"service": false,
 		"commands": []any{
 			"testing",
@@ -166,39 +142,23 @@ func TestRenderDeploymentDockerfileForCLI(t *testing.T) {
 			"alpine": "3.1",
 		},
 	})
-	st.Run(stenciltest.RegenerateSnapshots())
 }
 
 func TestRenderDependabot(t *testing.T) {
-	st := stenciltest.New(t, ".github/dependabot.yml.tpl", libraryTmpls...)
-	st.Args(map[string]interface{}{
+	assertTemplateSnapshot(t, ".github/dependabot.yml.tpl", map[string]interface{}{
 		"service":           true,
 		"serviceActivities": []interface{}{"grpc"},
 		"grpcClients":       []interface{}{"node"},
 	})
-	st.Run(stenciltest.RegenerateSnapshots())
 }
 
 func TestBasicGoMod(t *testing.T) {
-	st := stenciltest.New(t, "go.mod.tpl", libraryTmpls...)
-
-	p, err := plugin.NewStencilGolangPlugin(context.Background())
-	if err != nil {
-		t.Fatal(err)
-	}
-
-	st.Ext("github.com/getoutreach/stencil-golang", p)
+	st := newStencilTestWithGolangPlugin(t, "go.mod.tpl", nil)
 	st.Run(stenciltest.RegenerateSnapshots())
 }
 
 func TestMergeGoMod(t *testing.T) {
-	st := stenciltest.New(t, "go.mod.tpl", libraryTmpls...)
-
-	p, err := plugin.NewStencilGolangPlugin(context.Background())
-	if err != nil {
-		t.Fatal(err)
-	}
-	st.Ext("github.com/getoutreach/stencil-golang", p)
+	st := newStencilTestWithGolangPlugin(t, "go.mod.tpl", nil)
 
 	// HACK: We need to support copying arbitrary files in stenciltest so we
 	// don't have to pollute the current working directory with a go.mod file.
@@ -211,25 +171,16 @@ func TestMergeGoMod(t *testing.T) {
 }
 
 func TestGoModStanzaVersion(t *testing.T) {
-	st := stenciltest.New(t, "go.mod.tpl", libraryTmpls...)
-	st.Args(map[string]interface{}{
+	st := newStencilTestWithGolangPlugin(t, "go.mod.tpl", map[string]interface{}{
 		"go": map[string]interface{}{
 			"stanza": "1.19",
 		},
 	})
-
-	p, err := plugin.NewStencilGolangPlugin(context.Background())
-	if err != nil {
-		t.Fatal(err)
-	}
-
-	st.Ext("github.com/getoutreach/stencil-golang", p)
 	st.Run(stenciltest.RegenerateSnapshots())
 }
 
 func TestDevenvYaml(t *testing.T) {
-	st := stenciltest.New(t, "devenv.yaml.tpl", libraryTmpls...)
-	st.Args(map[string]any{
+	assertTemplateSnapshot(t, "devenv.yaml.tpl", map[string]any{
 		"service": true,
 		"dependencies": map[string]any{
 			"required": []any{
@@ -241,73 +192,58 @@ func TestDevenvYaml(t *testing.T) {
 			},
 		},
 	})
-	st.Run(stenciltest.RegenerateSnapshots())
 }
 
 func TestNonServiceDevenvYaml(t *testing.T) {
-	st := stenciltest.New(t, "devenv.yaml.tpl", libraryTmpls...)
-	st.Run(stenciltest.RegenerateSnapshots())
+	assertTemplateSnapshot(t, "devenv.yaml.tpl", nil)
 }
 
 func TestDevspaceYaml(t *testing.T) {
 	fakeDockerPullRegistry(t)
-	st := stenciltest.New(t, "devspace.yaml.tpl", libraryTmpls...)
-	st.Args(map[string]any{
+	assertTemplateSnapshot(t, "devspace.yaml.tpl", map[string]any{
 		"service": true,
 	})
-	st.Run(stenciltest.RegenerateSnapshots())
 }
 
 func TestVSCodeLaunchConfig(t *testing.T) {
-	st := stenciltest.New(t, ".vscode/launch.json.tpl", libraryTmpls...)
-	st.Args(map[string]interface{}{
+	assertTemplateSnapshot(t, ".vscode/launch.json.tpl", map[string]interface{}{
 		"service": true,
 	})
-	st.Run(stenciltest.RegenerateSnapshots())
 }
 
 func TestVSCodePrivateEnv(t *testing.T) {
-	st := stenciltest.New(t, ".vscode/private.env.tpl", libraryTmpls...)
-	st.Args(map[string]any{
+	assertTemplateSnapshot(t, ".vscode/private.env.tpl", map[string]any{
 		"service": true,
 	})
-	st.Run(stenciltest.RegenerateSnapshots())
 }
 
 func TestVSCodePrivateEnvNonService(t *testing.T) {
-	st := stenciltest.New(t, ".vscode/private.env.tpl", libraryTmpls...)
-	st.Run(stenciltest.RegenerateSnapshots())
+	assertTemplateSnapshot(t, ".vscode/private.env.tpl", nil)
 }
 
 func TestVSCodeSettingsConfig(t *testing.T) {
-	st := stenciltest.New(t, ".vscode/settings.json.tpl", libraryTmpls...)
-	st.Run(stenciltest.RegenerateSnapshots())
+	assertTemplateSnapshot(t, ".vscode/settings.json.tpl", nil)
 }
 
 func TestVSCodeSettingsConfigGofumpt(t *testing.T) {
-	st := stenciltest.New(t, ".vscode/settings.json.tpl", libraryTmpls...)
-	st.Args(map[string]any{
+	assertTemplateSnapshot(t, ".vscode/settings.json.tpl", map[string]any{
 		"go": map[string]any{
 			"formatter": "gofumpt",
 		},
 	})
-	st.Run(stenciltest.RegenerateSnapshots())
 }
 
 func TestGRPCServerRPC(t *testing.T) {
-	st := stenciltest.New(t, "internal/appName/rpc/rpc.go.tpl", libraryTmpls...)
-	st.Args(map[string]interface{}{
+	assertTemplateSnapshot(t, "internal/appName/rpc/rpc.go.tpl", map[string]interface{}{
 		"service": true,
 		"serviceActivities": []interface{}{
 			"grpc",
 		},
 	})
-	st.Run(stenciltest.RegenerateSnapshots())
 }
 
 func TestGoreleaserYml(t *testing.T) {
-	st := stenciltest.New(t, ".goreleaser.yml.tpl", libraryTmpls...)
-	st.Args(map[string]interface{}{
+	assertTemplateSnapshot(t, ".goreleaser.yml.tpl", map[string]interface{}{
 		"commands": []interface{}{
 			"cmd1",
 			"cmd2",
@@ -316,31 +252,25 @@ func TestGoreleaserYml(t *testing.T) {
 			"cmd4_sub1",
 		},
 	})
-	st.Run(stenciltest.RegenerateSnapshots())
 }
 
 func TestRenderGolangcilintYaml(t *testing.T) {
-	st := stenciltest.New(t, "scripts/golangci.yml.tpl", libraryTmpls...)
-	st.Args(map[string]interface{}{
+	assertTemplateSnapshot(t, "scripts/golangci.yml.tpl", map[string]interface{}{
 		"lintroller": "platinum",
 	})
-	st.Run(stenciltest.RegenerateSnapshots())
 }
 
 func TestRenderGolangcilintYamlGofumpt(t *testing.T) {
-	st := stenciltest.New(t, "scripts/golangci.yml.tpl", libraryTmpls...)
-	st.Args(map[string]any{
+	assertTemplateSnapshot(t, "scripts/golangci.yml.tpl", map[string]any{
 		"lintroller": "platinum",
 		"go": map[string]any{
 			"formatter": "gofumpt",
 		},
 	})
-	st.Run(stenciltest.RegenerateSnapshots())
 }
 
 func TestRenderGolangcilintYamlStrict(t *testing.T) {
-	st := stenciltest.New(t, "scripts/golangci.yml.tpl", libraryTmpls...)
-	st.Args(map[string]any{
+	assertTemplateSnapshot(t, "scripts/golangci.yml.tpl", map[string]any{
 		"lintroller": "platinum",
 		"go": map[string]any{
 			"linters": map[string]any{
@@ -348,12 +278,10 @@ func TestRenderGolangcilintYamlStrict(t *testing.T) {
 			},
 		},
 	})
-	st.Run(stenciltest.RegenerateSnapshots())
 }
 
 func TestUrfaveCLIV2(t *testing.T) {
-	st := stenciltest.New(t, "cmd/main_cli.go.tpl", libraryTmpls...)
-	st.Args(map[string]any{
+	assertTemplateSnapshot(t, "cmd/main_cli.go.tpl", map[string]any{
 		"commands": []any{
 			"cmd1",
 		},
@@ -361,12 +289,10 @@ func TestUrfaveCLIV2(t *testing.T) {
 			"urfave-cli": "v2",
 		},
 	})
-	st.Run(stenciltest.RegenerateSnapshots())
 }
 
 func TestUrfaveCLIV3(t *testing.T) {
-	st := stenciltest.New(t, "cmd/main_cli.go.tpl", libraryTmpls...)
-	st.Args(map[string]any{
+	assertTemplateSnapshot(t, "cmd/main_cli.go.tpl", map[string]any{
 		"commands": []any{
 			"cmd1",
 		},
@@ -374,14 +300,11 @@ func TestUrfaveCLIV3(t *testing.T) {
 			"urfave-cli": "v3",
 		},
 	})
-	st.Run(stenciltest.RegenerateSnapshots())
 }
 func TestRenderNodeJSPackageHJSON(t *testing.T) {
-	st := stenciltest.New(t, "api/clients/node/package.hjson.tpl", libraryTmpls...)
-	st.Args(map[string]any{
+	assertTemplateSnapshot(t, "api/clients/node/package.hjson.tpl", map[string]any{
 		"service":           true,
 		"serviceActivities": []any{"grpc"},
 		"grpcClients":       []any{"node"},
 	})
-	st.Run(stenciltest.RegenerateSnapshots())
 }

--- a/templates/ruby_test.go
+++ b/templates/ruby_test.go
@@ -6,31 +6,23 @@ package main_test
 
 import (
 	"testing"
-
-	"github.com/getoutreach/stencil/pkg/stenciltest"
 )
 
 func TestIncludeRubyToolVersionsIfRubyGRPCClient(t *testing.T) {
-	st := stenciltest.New(t, "testdata/tool-versions-ruby/.tool-versions.tpl", libraryTmpls...)
-	st.Args(map[string]interface{}{
+	assertTemplateSnapshot(t, "testdata/tool-versions-ruby/.tool-versions.tpl", map[string]interface{}{
 		"grpcClients": []interface{}{"ruby"},
 	})
-	st.Run(stenciltest.RegenerateSnapshots())
 }
 
 func TestIncludeRubyToolVersionsIfRubyGRPCClientLibrary(t *testing.T) {
 	// Need to use testdata because stenciltest cannot test file.Skip
-	st := stenciltest.New(t, "testdata/tool-versions-ruby/.tool-versions.tpl", libraryTmpls...)
-	st.Args(map[string]interface{}{
+	assertTemplateSnapshot(t, "testdata/tool-versions-ruby/.tool-versions.tpl", map[string]interface{}{
 		"grpcClients":       []interface{}{"ruby"},
 		"service":           false,
 		"serviceActivities": []interface{}{},
 	})
-	st.Run(stenciltest.RegenerateSnapshots())
 }
 
 func TestDontIncludeRubyToolVersionsIfNotRubyGRPCClient(t *testing.T) {
-	st := stenciltest.New(t, "testdata/tool-versions-ruby/.tool-versions.tpl", libraryTmpls...)
-	st.Args(map[string]interface{}{})
-	st.Run(stenciltest.RegenerateSnapshots())
+	assertTemplateSnapshot(t, "testdata/tool-versions-ruby/.tool-versions.tpl", map[string]interface{}{})
 }

--- a/templates/ruby_test.go
+++ b/templates/ruby_test.go
@@ -9,14 +9,14 @@ import (
 )
 
 func TestIncludeRubyToolVersionsIfRubyGRPCClient(t *testing.T) {
-	assertTemplateSnapshot(t, "testdata/tool-versions-ruby/.tool-versions.tpl", map[string]interface{}{
+	assertTemplateSnapshot(t, "testdata/tool-versions-ruby/.tool-versions.tpl", map[string]any{
 		"grpcClients": []interface{}{"ruby"},
 	})
 }
 
 func TestIncludeRubyToolVersionsIfRubyGRPCClientLibrary(t *testing.T) {
 	// Need to use testdata because stenciltest cannot test file.Skip
-	assertTemplateSnapshot(t, "testdata/tool-versions-ruby/.tool-versions.tpl", map[string]interface{}{
+	assertTemplateSnapshot(t, "testdata/tool-versions-ruby/.tool-versions.tpl", map[string]any{
 		"grpcClients":       []interface{}{"ruby"},
 		"service":           false,
 		"serviceActivities": []interface{}{},
@@ -24,5 +24,5 @@ func TestIncludeRubyToolVersionsIfRubyGRPCClientLibrary(t *testing.T) {
 }
 
 func TestDontIncludeRubyToolVersionsIfNotRubyGRPCClient(t *testing.T) {
-	assertTemplateSnapshot(t, "testdata/tool-versions-ruby/.tool-versions.tpl", map[string]interface{}{})
+	assertTemplateSnapshot(t, "testdata/tool-versions-ruby/.tool-versions.tpl", map[string]any{})
 }

--- a/templates/test_helpers_test.go
+++ b/templates/test_helpers_test.go
@@ -1,12 +1,12 @@
 package main_test
 
 import (
-	"context"
 	"maps"
 	"testing"
 
 	"github.com/getoutreach/stencil-golang/internal/plugin"
 	"github.com/getoutreach/stencil/pkg/stenciltest"
+	"gotest.tools/v3/assert"
 )
 
 // stencilArgs provides base arguments which are merged with the
@@ -38,10 +38,8 @@ func newStencilTestWithGolangPlugin(t *testing.T, templateFilename string, args 
 	t.Helper()
 	st := newStencilTest(t, templateFilename, args)
 
-	p, err := plugin.NewStencilGolangPlugin(context.Background())
-	if err != nil {
-		t.Fatal(err)
-	}
+	p, err := plugin.NewStencilGolangPlugin(t.Context())
+	assert.NilError(t, err)
 	st.Ext("github.com/getoutreach/stencil-golang", p)
 
 	return st

--- a/templates/test_helpers_test.go
+++ b/templates/test_helpers_test.go
@@ -1,0 +1,55 @@
+package main_test
+
+import (
+	"context"
+	"maps"
+	"testing"
+
+	"github.com/getoutreach/stencil-golang/internal/plugin"
+	"github.com/getoutreach/stencil/pkg/stenciltest"
+)
+
+// stencilArgs provides base arguments which are merged with the
+// provided extra stencil Arguments.
+func stencilArgs(extraArgs map[string]any) map[string]any {
+	args := map[string]any{
+		"description":   "stenciled repo",
+		"reportingTeam": "org-team",
+	}
+
+	maps.Copy(args, extraArgs)
+
+	return args
+}
+
+// newStencilTest creates a new stencil test instance with the provided
+// template filename and extra arguments merged with the base arguments.
+func newStencilTest(t *testing.T, templateFilename string, args map[string]any, helpers ...string) *stenciltest.Template {
+	t.Helper()
+	allHelpers := append([]string{"_helpers.tpl"}, helpers...)
+	st := stenciltest.New(t, templateFilename, allHelpers...)
+	st.Args(stencilArgs(args))
+	return st
+}
+
+// newStencilTestWithGolangPlugin creates a new stencil test instance with the
+// stencil-golang plugin extension registered.
+func newStencilTestWithGolangPlugin(t *testing.T, templateFilename string, args map[string]any) *stenciltest.Template {
+	t.Helper()
+	st := newStencilTest(t, templateFilename, args)
+
+	p, err := plugin.NewStencilGolangPlugin(context.Background())
+	if err != nil {
+		t.Fatal(err)
+	}
+	st.Ext("github.com/getoutreach/stencil-golang", p)
+
+	return st
+}
+
+// assertTemplateSnapshot is a helper to validate a given template against a snapshot.
+func assertTemplateSnapshot(t *testing.T, templateFilename string, args map[string]any, helpers ...string) {
+	t.Helper()
+	st := newStencilTest(t, templateFilename, args, helpers...)
+	st.Run(stenciltest.RegenerateSnapshots())
+}


### PR DESCRIPTION
## What this PR does / why we need it

Reduces the amount of coupling amongst the Stencil modules, and cleans up the module in preparation for `stencil lint`.

## Jira ID

[DT-5446]

## Notes for your reviewers

Since we added a dependency on `stencil-circleci` (there are no consumers of this module that don't already depend on `stencil-circleci` per a scan by AI), the tests needed to be updated so that certain required arguments were added to all of the tests.

Related PR:

- https://github.com/getoutreach/stencil-circleci/pull/232


[DT-5446]: https://outreach-io.atlassian.net/browse/DT-5446?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ